### PR TITLE
Fix fetching sealed status during resync when using cache before flush to db

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2263,7 +2263,7 @@ class BlockProcessor:
 
     # Populate the sealed status of an atomical
     def populate_sealed_status(self, atomical):
-        sealed_location = self.db.get_sealed_location(atomical['atomical_id'])
+        sealed_location = self.get_general_data_with_cache(atomical['atomical_id'])
         if sealed_location:
             atomical['$sealed'] = location_id_bytes_to_compact(sealed_location)
  
@@ -2293,7 +2293,7 @@ class BlockProcessor:
             dmint_format_status['errors'].append('items cannot be set manually for dmint')
             dmint_format_status['status'] = 'invalid'
 
-        sealed_location = self.db.get_sealed_location(atomical_id)
+        sealed_location = self.get_general_data_with_cache(b'sealed' + atomical_id)
         if not sealed_location:
             dmint_format_status['errors'].append('container not sealed')
             dmint_format_status['status'] = 'invalid'

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -1182,10 +1182,6 @@ class DB:
         hashX_pairs = await run_in_thread(lookup_hashXs)
         return await run_in_thread(lookup_utxos, hashX_pairs)
 
-    # Get the sealed location of an atomical (if it's sealed)
-    def get_sealed_location(self, atomical_id):
-        return self.utxo_db.get(b'sealed' + atomical_id)
-
     # Get the raw mint information for an atomical
     def get_atomical_mint_info_dump(self, atomical_id):
         return self.utxo_db.get(b'mi' + atomical_id)


### PR DESCRIPTION
Correctly retrieve sealed status from db and the temporary cache used during a full sync.

If this change is not made, then a container may appear not sealed and therefore any subsequent dmint attempts would be considered invalid and therefore corrupt the index.