### PR TITLE
Efficiency improvements, new version of split (now called 'skip' operation), and more fixes...

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1104,7 +1104,7 @@ def parse_protocols_operations_from_witness_array(tx, tx_hash):
             # Also enforce that if there are meta, args, or ctx fields that they must be dicts
             # This is done to ensure that these fields are always easily parseable and do not contain unexpected data which could cause parsing problems later
             # Ensure that they are not allowed to contain bytes like objects
-            if not is_sanitized_dict_whitelist_only(decoded_object.get('meta', {})) or not is_sanitized_dict_whitelist_only(decoded_object.get('args', {})) or not is_sanitized_dict_whitelist_only(decoded_object.get('ctx', {})) or not is_sanitized_dict_whitelist_only(decoded_object.get('init', {}), True):
+            if not is_sanitized_dict_whitelist_only(decoded_object.get('meta', {})) or not is_sanitized_dict_whitelist_only(decoded_object.get('args', {}, True)) or not is_sanitized_dict_whitelist_only(decoded_object.get('ctx', {})) or not is_sanitized_dict_whitelist_only(decoded_object.get('init', {}), True):
                 print(f'parse_protocols_operations_from_witness_array found {op_name} but decoded CBOR payload has an args, meta, ctx, or init that has not permitted data type {tx} {decoded_object}. Skipping tx input...')
                 continue  
             #if op_name != 'nft' and op_name != 'ft' and op_name != 'dft' and not is_sanitized_dict_whitelist_only(decoded_object):
@@ -1727,9 +1727,16 @@ def validate_merkle_proof_dmint(expected_root_hash, item_name, possible_bitworkc
         formatted_proof = []
         for item in proof:
             if item['p']:
-                formatted_proof.append({
-                    'right': item['d']
-                })
+                # Also accept bytes type
+                # Note: must enable bytes types in the args for the base parser before this can actually work
+                if isinstance(item['d'], bytes):
+                    formatted_proof.append({
+                        'right': item['d'].hex()
+                    })
+                else:
+                    formatted_proof.append({
+                        'right': item['d']
+                    })
             else: 
                 formatted_proof.append({
                     'left': item['d']

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -64,7 +64,9 @@ from electrumx.lib.util_atomicals import (
     AtomicalsValidationError,
     get_container_dmint_format_status,
     validate_dmitem_mint_args_with_container_dmint,
-    calculate_nft_output_index_legacy
+    calculate_nft_output_index_legacy,
+    contains_valid_skip_operation,
+    get_start_index_for_ft
 )
 
 import copy
@@ -512,8 +514,6 @@ class BlockProcessor:
         tx, tx_hash = self.coin.DESERIALIZER(bytes.fromhex(raw_tx), 0).read_tx_and_hash()
         # Determine if there are any other operations at the transfer 
         operations_found_at_inputs = parse_protocols_operations_from_witness_array(tx, tx_hash)
-        # Check if it was the split y operation because that is handled differently
-        # should_split_ft_atomicals = operations_found_at_inputs and operations_found_at_inputs.get('op') == 'y' and operations_found_at_inputs.get('input_index') == 0 and operations_found_at_inputs.get('payload')
         # Build the map of the atomicals potentiall spent at the tx
         atomicals_spent_at_inputs = self.build_atomicals_spent_at_inputs_for_validation_only(tx)
         # Build a structure of organizing into NFT and FTs
@@ -524,8 +524,6 @@ class BlockProcessor:
         if len(ft_atomicals) == 0:
             return True 
 
-        # Prepare the logic check to determine if the FTs are cleanly assigned (ie: no accidental burning loss would occur)
-        cleanly_assigned = False
         cleanly_assigned = self.color_ft_atomicals_regular(ft_atomicals, tx_hash, tx, 0, operations_found_at_inputs, [], self.height, False)
         # Everything would have been cleanly assigned
         if cleanly_assigned:
@@ -1519,10 +1517,7 @@ class BlockProcessor:
                     found_atomical_at_input = True 
                     expected_output_index = next_output_idx
                     if expected_output_index >= len(tx.outputs) or is_unspendable_genesis(tx.outputs[expected_output_index].pk_script) or is_unspendable_legacy(tx.outputs[expected_output_index].pk_script):
-                        expected_output_index = 0
-                    # Also keep them at the 0'th index if the split command was used
-                    # if operations_found_at_inputs and operations_found_at_inputs.get('op') == 'y' and operations_found_at_inputs.get('input_index') == 0:
-                    #    expected_output_index = 0      
+                        expected_output_index = 0    
                     map_output_idxs_for_atomicals[expected_output_index] = map_output_idxs_for_atomicals.get(expected_output_index) or {}
                     map_output_idxs_for_atomicals[expected_output_index][atomical_id] = atomical_info
                 if found_atomical_at_input:
@@ -1580,14 +1575,15 @@ class BlockProcessor:
             atomical_ids_touched.append(atomical_id)
             output_colored_map[atomical_id] = expected_output_index
         return output_colored_map
+    
     def color_ft_atomicals_split(self, ft_atomicals, tx_hash, tx, tx_num, operations_found_at_inputs, atomical_ids_touched, live_run):
         cleanly_assigned = True
         for atomical_id, mint_info in sorted(ft_atomicals.items()):
             expected_output_indexes = []
             remaining_value = mint_info['value']
-            # The FT type has the 'split' (y) method which allows us to selectively split (skip) a certain total number of token units (satoshis)
+            # The FT type has the 'skip' (y) method which allows us to skip a certain total number of token units (satoshis)
             # before beginning to color the outputs.
-            # Essentially this makes it possible to "split" out multiple FT's located at the same input
+            # Essentially this makes it possible to "skip" out multiple FT's located at the same input
             # If the input at index 0 has the split operation, then it will apply for the atomical token generally across all inputs and the first output will be skipped
             total_amount_to_skip = 0
             # Uses the compact form of atomical id as the keys for developer convenience
@@ -1626,7 +1622,7 @@ class BlockProcessor:
   
     def color_ft_atomicals_regular_perform(self, ft_atomicals, tx_hash, tx, tx_num, operations_found_at_inputs, atomical_ids_touched, height, live_run, sort_fifo):
         self.logger.info(f'color_ft_atomicals_regular_perform tx_hash={hash_to_hex_str(tx_hash)} start check')
-        atomical_id_to_expected_outs_map, cleanly_assigned, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, sort_fifo)
+        atomical_id_to_expected_outs_map, cleanly_assigned, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, sort_fifo, get_start_index_for_ft(operations_found_at_inputs))
         if not atomical_id_to_expected_outs_map:
             return None
         self.logger.info(f'color_ft_atomicals_regular_perform tx_hash={hash_to_hex_str(tx_hash)} return ft_atomicals={ft_atomicals} atomical_id_to_expected_outs_map={atomical_id_to_expected_outs_map}')
@@ -1747,11 +1743,6 @@ class BlockProcessor:
         
         # Process the FTs
         if len(ft_atomicals) > 0:
-            # should_split_ft_atomicals = operations_found_at_inputs and operations_found_at_inputs.get('op') == 'y' and operations_found_at_inputs.get('input_index') == 0 and operations_found_at_inputs.get('payload')
-            # if should_split_ft_atomicals:
-            #     if not self.color_ft_atomicals_split(ft_atomicals, tx_hash, tx, tx_num, operations_found_at_inputs, atomical_ids_touched, True):
-            #         self.logger.info(f'color_atomicals_outputs:color_ft_atomicals_split cleanly_assigned=False tx_hash={tx_hash}')
-            # else:
             if not self.color_ft_atomicals_regular(ft_atomicals, tx_hash, tx, tx_num, operations_found_at_inputs, atomical_ids_touched, height, True):
                 self.logger.info(f'color_atomicals_outputs:color_ft_atomicals_regular cleanly_assigned=False tx_hash={tx_hash}')
         return atomical_ids_touched
@@ -2466,16 +2457,16 @@ class BlockProcessor:
         # Populate the request specific fields
         atomical['$request_dmitem'] = atomical['mint_info'].get('$request_dmitem')
         atomical['$parent_container'] = atomical['mint_info'].get('$parent_container')
+         # Resolve the parent to get the parent container name
+        parent_container = self.get_base_mint_info_by_atomical_id(pid)
+        if not parent_container:
+            atomical_id = atomical['mint_info']['id']
+            raise IndexError(f'populate_dmitem_subtype_specific_fields: parent container not found atomical_id={atomical_id}, parent_container={parent_container}')
+        atomical['$parent_container_name'] = parent_container['$container'] 
         if status == 'verified' and candidate_id == atomical['atomical_id']:
             atomical['subtype'] = 'dmitem'
             atomical['$dmitem'] = request_dmitem
-            atomical['$parent_container'] = pid_compact
-            # Resolve the parent to get the parent path and construct the full_realm_name
-            parent_container = self.get_base_mint_info_by_atomical_id(pid)
-            if not parent_container:
-                atomical_id = atomical['mint_info']['id']
-                raise IndexError(f'populate_dmitem_subtype_specific_fields: parent container not found atomical_id={atomical_id}, parent_container={parent_container}')
-            atomical['$parent_container_name'] = parent_container['$container']
+         
             return request_dmitem, True
         return request_dmitem, False
 
@@ -2567,7 +2558,7 @@ class BlockProcessor:
             self.logger.info(f'create_or_delete_decentralized_mint_output: commit_txid not found for distmint reveal_tx {hash_to_hex_str(commit_txid)}. Skipping...')
             return None
         if commit_tx_height < mint_height:
-            self.logger.info(f'create_or_delete_decentralized_mint_output: commit_tx_height={commit_tx_height} is less than ATOMICALS_ACTIVATION_HEIGHT. Skipping...')
+            self.logger.info(f'create_or_delete_decentralized_mint_output: commit_tx_height={commit_tx_height} is less than mint_height={mint_height}. Skipping...')
             return None
 
         expected_output_index = 0
@@ -2792,12 +2783,12 @@ class BlockProcessor:
                     append_hashX(double_sha256(atomical_id))
                 
                 # Check if there were any payments for subrealms in tx
-                if self.create_or_delete_subrealm_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_spent_at_inputs):
+                if self.create_or_delete_subrealm_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, True):
                     self.logger.info(f'advance_txs: found valid payment create_or_delete_subrealm_payment_output_if_valid {hash_to_hex_str(tx_hash)}')
                     has_at_least_one_valid_atomicals_operation = True
 
                 # Check if there were any payments for dmitems in tx
-                if self.create_or_delete_dmitem_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_spent_at_inputs):
+                if self.create_or_delete_dmitem_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, True):
                     self.logger.info(f'advance_txs: found valid payment create_or_delete_dmitem_payment_output_if_valid {hash_to_hex_str(tx_hash)}')
                     has_at_least_one_valid_atomicals_operation = True
 
@@ -2844,7 +2835,7 @@ class BlockProcessor:
 
     # Check for for output markers for a payment for a subrealm
     # Same function is used for creating and rollback. Set Delete=True for rollback operation
-    def create_or_delete_subrealm_payment_output_if_valid(self, tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, Delete=False):
+    def create_or_delete_subrealm_payment_output_if_valid(self, tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, Delete):
         # Add the new UTXOs
         found_atomical_id_for_potential_subrealm = None
         for idx, txout in enumerate(tx.outputs):
@@ -2867,7 +2858,7 @@ class BlockProcessor:
             
             # Each of the elements in the expected script output map must be satisfied for it to be a valid payment
             nft_atomicals, ft_atomicals = self.build_atomical_type_structs(atomicals_spent_at_inputs)
-            atomical_id_to_output_index_map, ignore, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, self.is_dmint_activated(height))
+            atomical_id_to_output_index_map, ignore, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, self.is_dmint_activated(height), get_start_index_for_ft(atomicals_operations_found_at_inputs))
             output_idx_to_atomical_id_map = build_reverse_output_to_atomical_id_map(atomical_id_to_output_index_map)
             expected_output_keys_satisfied = {}
             for output_script_key, output_script_details in expected_payment_outputs.items():
@@ -2932,7 +2923,7 @@ class BlockProcessor:
         return None 
 
     # Same function is used for creating and rollback. Set Delete=True for rollback operation
-    def create_or_delete_dmitem_payment_output_if_valid(self, tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, Delete=False):
+    def create_or_delete_dmitem_payment_output_if_valid(self, tx_hash, tx, tx_num, height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, Delete):
         # Add the new UTXOs
         found_atomical_id_for_potential_dmitem = None
         for idx, txout in enumerate(tx.outputs):
@@ -2955,7 +2946,7 @@ class BlockProcessor:
             # Each of the elements in the expected script output map must be satisfied for it to be a valid payment
             nft_atomicals, ft_atomicals = self.build_atomical_type_structs(atomicals_spent_at_inputs)
             # Map the ARC20 fungible tokens first
-            atomical_id_to_output_index_map, ignore, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, self.is_dmint_activated(height))
+            atomical_id_to_output_index_map, ignore, atomicals_list_result = calculate_outputs_to_color_for_ft_atomical_ids(ft_atomicals, tx_hash, tx, self.is_dmint_activated(height), get_start_index_for_ft(atomicals_operations_found_at_inputs))
             output_idx_to_atomical_id_map = build_reverse_output_to_atomical_id_map(atomical_id_to_output_index_map)
             # Future enhancement is to allow minting by NFT and or holding a realm/subrealm, or glob patterns like txid
             expected_output_keys_satisfied = {}
@@ -3294,10 +3285,10 @@ class BlockProcessor:
                 atomicals_minted += 1
             
             # Rollback any subrealm payments
-            self.create_or_delete_subrealm_payment_output_if_valid(tx_hash, tx, tx_num, self.height, atomicals_spent_at_inputs, True)
+            self.create_or_delete_subrealm_payment_output_if_valid(tx_hash, tx, tx_num, self.height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, True)
 
             # Rollback any dmint payments
-            self.create_or_delete_dmitem_payment_output_if_valid(tx_hash, tx, tx_num, self.height, atomicals_spent_at_inputs, True)
+            self.create_or_delete_dmitem_payment_output_if_valid(tx_hash, tx, tx_num, self.height, atomicals_spent_at_inputs, atomicals_operations_found_at_inputs, True)
 
             # If there were any distributed mint creation, then delete
             self.create_or_delete_decentralized_mint_output(operations_found_at_inputs, tx_num, tx_hash, tx, self.height, True)

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -65,7 +65,6 @@ from electrumx.lib.util_atomicals import (
     get_container_dmint_format_status,
     validate_dmitem_mint_args_with_container_dmint,
     calculate_nft_output_index_legacy,
-    contains_valid_skip_operation,
     get_start_index_for_ft
 )
 

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2783,7 +2783,6 @@ class BlockProcessor:
                     append_hashX(double_sha256(created_atomical_id))
                     self.logger.info(f'advance_txs: create_or_delete_atomical created_atomical_id atomical_id={created_atomical_id.hex()}, tx_hash={hash_to_hex_str(tx_hash)}')
 
-
                 # Color the outputs of any transferred NFT/FT atomicals according to the rules
                 atomical_ids_transferred = self.color_atomicals_outputs(atomicals_operations_found_at_inputs, atomicals_spent_at_inputs, tx, tx_hash, tx_num, height, is_unspendable)
                 for atomical_id in atomical_ids_transferred:


### PR DESCRIPTION
Changes:

- Add split operation to function by skipping the 0'th output for FTs only if found. This allows the NFTs to go to the 0th output and all FTs will start from the 1st output

- Accept args bytes to accept merkle proof in bytes for dmint

- add "parent_container_name" to all dmint requests now