### PR TITLE
feat:add get holders by atomical_id

### DIFF
--- a/electrumx/lib/segwit_addr.py
+++ b/electrumx/lib/segwit_addr.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2017, 2020 Pieter Wuille
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""Reference implementation for Bech32/Bech32m and segwit addresses."""
+
+
+from enum import Enum
+
+class Encoding(Enum):
+    """Enumeration type to list the various supported encodings."""
+    BECH32 = 1
+    BECH32M = 2
+
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+BECH32M_CONST = 0x2bc830a3
+
+def bech32_polymod(values):
+    """Internal function that computes the Bech32 checksum."""
+    generator = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for value in values:
+        top = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= generator[i] if ((top >> i) & 1) else 0
+    return chk
+
+
+def bech32_hrp_expand(hrp):
+    """Expand the HRP into values for checksum computation."""
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def bech32_verify_checksum(hrp, data):
+    """Verify a checksum given HRP and converted data characters."""
+    const = bech32_polymod(bech32_hrp_expand(hrp) + data)
+    if const == 1:
+        return Encoding.BECH32
+    if const == BECH32M_CONST:
+        return Encoding.BECH32M
+    return None
+
+def bech32_create_checksum(hrp, data, spec):
+    """Compute the checksum values given HRP and data."""
+    values = bech32_hrp_expand(hrp) + data
+    const = BECH32M_CONST if spec == Encoding.BECH32M else 1
+    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ const
+    return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
+
+
+def bech32_encode(hrp, data, spec):
+    """Compute a Bech32 string given HRP and data values."""
+    combined = data + bech32_create_checksum(hrp, data, spec)
+    return hrp + '1' + ''.join([CHARSET[d] for d in combined])
+
+def bech32_decode(bech):
+    """Validate a Bech32/Bech32m string, and determine HRP and data."""
+    if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
+            (bech.lower() != bech and bech.upper() != bech)):
+        return (None, None, None)
+    bech = bech.lower()
+    pos = bech.rfind('1')
+    if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
+        return (None, None, None)
+    if not all(x in CHARSET for x in bech[pos+1:]):
+        return (None, None, None)
+    hrp = bech[:pos]
+    data = [CHARSET.find(x) for x in bech[pos+1:]]
+    spec = bech32_verify_checksum(hrp, data)
+    if spec is None:
+        return (None, None, None)
+    return (hrp, data[:-6], spec)
+
+def convertbits(data, frombits, tobits, pad=True):
+    """General power-of-2 base conversion."""
+    acc = 0
+    bits = 0
+    ret = []
+    maxv = (1 << tobits) - 1
+    max_acc = (1 << (frombits + tobits - 1)) - 1
+    for value in data:
+        if value < 0 or (value >> frombits):
+            return None
+        acc = ((acc << frombits) | value) & max_acc
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad:
+        if bits:
+            ret.append((acc << (tobits - bits)) & maxv)
+    elif bits >= frombits or ((acc << (tobits - bits)) & maxv):
+        return None
+    return ret
+
+
+def decode(hrp, addr):
+    """Decode a segwit address."""
+    hrpgot, data, spec = bech32_decode(addr)
+    if hrpgot != hrp:
+        return (None, None)
+    decoded = convertbits(data[1:], 5, 8, False)
+    if decoded is None or len(decoded) < 2 or len(decoded) > 40:
+        return (None, None)
+    if data[0] > 16:
+        return (None, None)
+    if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
+        return (None, None)
+    if data[0] == 0 and spec != Encoding.BECH32 or data[0] != 0 and spec != Encoding.BECH32M:
+        return (None, None)
+    return (data[0], decoded)
+
+
+def encode(hrp, witver, witprog):
+    """Encode a segwit address."""
+    spec = Encoding.BECH32 if witver == 0 else Encoding.BECH32M
+    ret = bech32_encode(hrp, [witver] + convertbits(witprog, 8, 5), spec)
+    if decode(hrp, ret) == (None, None):
+        return None
+    return ret
+
+
+def segwit_scriptpubkey(witver, witprog):
+    """Construct a Segwit scriptPubKey for a given witness program."""
+    return bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog)

--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -41,6 +41,8 @@ from cbor2 import dumps, loads, CBORDecodeError
 from collections.abc import Mapping
 from functools import reduce
 from merkletools import MerkleTools
+from bitcointx.wallet import CCoinAddress, CBitcoinTestnetAddress
+from bitcointx.core.script import CScript
 
 class AtomicalsValidationError(Exception):
     '''Raised when Atomicals Validation Error'''
@@ -1769,3 +1771,23 @@ def validate_merkle_proof_dmint(expected_root_hash, item_name, possible_bitworkc
             return True, concat_str4, target_hash
 
     return False, None, None
+
+
+def get_address_from_output_script(p2tr_output_script_hex):
+    # this function temporary use bitcoinx to get address from outputscript
+    # I will rewrite this method later or use available Python standard libraries. 
+    # this method does not cover all use cases; it is just a provisional solution
+    try:
+        output_script = CScript.fromhex(p2tr_output_script_hex)
+        p2tr_address = CCoinAddress.from_scriptPubKey(output_script)
+        return str(p2tr_address)
+    except Exception as e:
+        pass
+    # for testnet
+    try:
+        output_script = CScript.fromhex(p2tr_output_script_hex)
+        p2tr_address = CBitcoinTestnetAddress.from_scriptPubKey(output_script)
+        return str(p2tr_address)
+    except Exception as e:
+        pass
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ websockets
 regex
 krock32
 merkletools
-python-bitcointx

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ websockets
 regex
 krock32
 merkletools
+python-bitcointx


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


Add a new api `blockchain.atomicals.get_atomical_holder`, it can receive three params. atomical_id, limit(default 100), offset(default 0). for example, if you want get 'avm' token holders. you can send by following curl command.

```
curl -X POST http://0.0.0.0:8080/proxy/blockchain.atomicals.get_atomical_holder -d '{"params":["d4c48c4db504282e987776cba26f78fbc1573460a02c45d9e5de37c5b13ef751i0", 3, 0]}' -H "Content-Type: application/json" | jq
```
will return:
```
{
  "success": true,
  "response": [
    {
      "percent": 0.01019047619047619,
      "address": "bc1pf70gkj3zcxqmq4v3cjjngnpalhajnsc8fld9wl9xq547pvqgqmmqjw6j2f",
      "holding": 214000
    },
    {
      "percent": 0.008952380952380953,
      "address": "bc1px95q3n0e39np6slcdxyy5rjr6erm54zk340wq45fxh5sg7skzq8q804wpj",
      "holding": 188000
    },
    {
      "percent": 0.008714285714285714,
      "address": "bc1p5ue8euvu74em4vdlytam25z2ypxzd7vnh9w6f227da5kzxmx66dqdqrvx6",
      "holding": 183000
    }
  ]
}
```

Use this api  should  install bitcointx pythonlib `pip3 install python-bitcointx`.
This lib depend on secp256k1. run `brew install secp256k1` on macOs, and run `apt-get install libsecp256k1-0`  on ubuntu.

