### PR TITLE
Correctly backup th on reorg

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -3389,7 +3389,7 @@ class BlockProcessor:
 
             # Check a proof of work record if there was valid proof of work attached to delete
             self.create_or_delete_pow_records(tx_hash, tx_num, self.height, operations_found_at_inputs, True)
-            self.delete_general_data(b'th' + pack_le_uint32(height) + pack_le_uint64(tx_num) + tx_hash, tx_hash)
+            self.delete_general_data(b'th' + pack_le_uint32(self.height) + pack_le_uint64(tx_num) + tx_hash, tx_hash)
 
             # Restore the inputs
             for txin in reversed(tx.inputs):


### PR DESCRIPTION
Fixes crash on reorg when reverting the `b'th'` records for atomical txs per block