### PR TITLE
fix get os env net error cause the function return none

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1775,14 +1775,11 @@ def validate_merkle_proof_dmint(expected_root_hash, item_name, possible_bitworkc
 
 def get_address_from_output_script(p2tr_output_script_hex):
     # this function is used for get address from outputscript
-    # I will rewrite this method later or use available Python standard libraries. 
-    # this method does not cover all use cases; it is just a provisional solution
     addr = ''
     try:
         # "bc" for mainnet, "tb" for testnet
-        if os.environ['NET'] == 'mainnet':
-            hrp = "bc"
-        elif os.environ['NET'] =='testnet':
+        hrp = "bc"
+        if os.environ.get('NET', "mainnet") =='testnet':
             hrp = "tb"
         witprog = list(bytes.fromhex(p2tr_output_script_hex))[2:34]
         witver = 1


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

In the old code, if you set `# NET=testnet` in config, the code couldn't get the NET var , the function will exception and return ''
![image](https://github.com/atomicals/atomicals-electrumx/assets/154503348/49e1fa00-ad1b-4b8c-8585-377ee63de57e)
