### PR TITLE
replace_get_address_function and fix During handling of the above exc…

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -42,7 +42,6 @@ from cbor2 import dumps, loads, CBORDecodeError
 from collections.abc import Mapping
 from functools import reduce
 from merkletools import MerkleTools
-from electrumx.lib.segwit_addr import segwit_scriptpubkey, encode
 
 class AtomicalsValidationError(Exception):
     '''Raised when Atomicals Validation Error'''
@@ -1757,19 +1756,3 @@ def validate_merkle_proof_dmint(expected_root_hash, item_name, possible_bitworkc
             return True, concat_str4, target_hash
 
     return False, None, None
-
-
-def get_address_from_output_script(p2tr_output_script_hex):
-    # this function is used for get address from outputscript
-    addr = ''
-    try:
-        # "bc" for mainnet, "tb" for testnet
-        hrp = "bc"
-        if os.environ.get('NET', "mainnet") =='testnet':
-            hrp = "tb"
-        witprog = list(bytes.fromhex(p2tr_output_script_hex))[2:34]
-        witver = 1
-        addr = encode(hrp, witver, witprog)
-    except Exception as e:
-        pass
-    return addr

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2124,16 +2124,16 @@ class BlockProcessor:
         
     async def get_base_mint_info_rpc_format_by_atomical_id(self, atomical_id):
         atomical_result = None
-        try:
+        if atomical_id in self.atomicals_rpc_format_cache:
             atomical_result = self.atomicals_rpc_format_cache[atomical_id]
-        except KeyError:
+        else:
             atomical_result = await self.get_base_mint_info_by_atomical_id_async(atomical_id)
             if not atomical_result:
                 return None
             convert_db_mint_info_to_rpc_mint_info_format(self.coin.header_hash, atomical_result)
             self.populate_extended_field_summary_atomical_info(atomical_id, atomical_result)
             self.atomicals_rpc_format_cache[atomical_id] = atomical_result
-        return atomical_result 
+        return atomical_result
 
     # Get the atomical details base info CACHED wrapper
     async def get_dft_mint_info_rpc_format_by_atomical_id(self, atomical_id):

--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -1402,9 +1402,6 @@ class DB:
                     location_value, = unpack_le_uint64(atomical_active_location_value[HASHX_LEN + SCRIPTHASH_LEN : HASHX_LEN + SCRIPTHASH_LEN + 8])
                     
                     script = location_script.hex()
-                    # TODO
-                    # some location atomical_id might be burned
-                    # the location alue will less than 1000
                     if holder_dict.get(script, None):
                         holder_dict[script] += location_value
                     else:

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -29,6 +29,7 @@ from aiorpcx import (Event, JSONRPCAutoDetect, JSONRPCConnection,
                      NewlineFramer, TaskTimeout, timeout_after, run_in_thread)
 
 import electrumx
+from electrumx.lib.script2addr import get_address_from_output_script
 import electrumx.lib.util as util
 from electrumx.lib.util import OldTaskGroup, unpack_le_uint64
 from electrumx.lib.util_atomicals import (
@@ -45,8 +46,7 @@ from electrumx.lib.util_atomicals import (
     validate_rules_data,
     AtomicalsValidationError,
     auto_encode_bytes_elements, 
-    validate_merkle_proof_dmint,
-    get_address_from_output_script
+    validate_merkle_proof_dmint
 )
 from electrumx.lib.hash import (HASHX_LEN, Base58Error, hash_to_hex_str,
                                 hex_str_to_hash, sha256, double_sha256)
@@ -1923,17 +1923,15 @@ class ElectrumX(SessionBase):
             max_supply = atomical.get('$max_supply', 0)
             for holder in atomical.get("holders", [])[offset:offset+limit]:
                 percent = holder['holding'] / max_supply
-                address = get_address_from_output_script(holder['script'])
                 formatted_results.append({
                     "percent": percent,
-                    "address": address,
+                    "address": get_address_from_output_script(bytes.fromhex(holder['script'])),
                     "holding": holder["holding"]
                 })
         elif atomical["type"] == "NFT":
             for holder in atomical.get("holders", [])[offset:offset+limit]:
-                address = get_address_from_output_script(holder['script'])
                 formatted_results.append({
-                    "address": address,
+                    "address": get_address_from_output_script(bytes.fromhex(holder['script'])),
                     "holding": holder["holding"]
                 })
         return formatted_results


### PR DESCRIPTION
1. Replace get address function, use lib/script2addr.py's `get_address_from_output_script` function
2. Fix block_processor.py get_base_mint_info_rpc_format_by_atomical_id function error, sometimes it will During handling of the above exception, another exception occurred:
```
WARNING:SessionManager:Traceback (most recent call last):
  File "/electrumx/electrumx/server/block_processor.py", line 2128, in get_base_mint_info_rpc_format_by_atomical_id
    atomical_result = self.atomicals_rpc_format_cache[atomical_id]
  File "/usr/local/lib/python3.9/site-packages/pylru.py", line 90, in __getitem__
    node = self.table[key]
KeyError: b"u\x14\xfb\xaeGx@'r\xa1\x83\x85\xca\x98\xb8j.\x8a!\x92\xc4e\xc5\xad\xbd\x8e\xd2\xa9\xd6\xfa\x9a\xc7\x00\x00\x00\x00"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
    atomical = await self.session_mgr.bp.get_base_mint_info_rpc_format_by_atomical_id(atomical_id)
  File "/electrumx/electrumx/server/block_processor.py", line 2135, in get_base_mint_info_rpc_format_by_atomical_id
    self.atomicals_rpc_format_cache[atomical_id] = atomical_result
  File "/usr/local/lib/python3.9/site-packages/pylru.py", line 140, in __setitem__
    del self.table[node.key]
KeyError: b'\xac\xbe4\x8c\\~5Oc\xf8\xd8r \xae\xe9\xfd8\xa8Q\xce\xd2x\xc9\x89\xeb\x81jX\xe6)\x9ad\x00\x00\x00\x00
```
Also can fix by increase atomicals_rpc_general_cache's count