### PR TITLE
fix import error and remove banner function

### DIFF
--- a/electrumx/server/http_session.py
+++ b/electrumx/server/http_session.py
@@ -13,7 +13,8 @@ from decimal import Decimal
 import electrumx
 from electrumx.lib.hash import HASHX_LEN, double_sha256, hash_to_hex_str, hex_str_to_hash, sha256
 import electrumx.lib.util as util
-from electrumx.lib.util_atomicals import SUBREALM_MINT_PATH, AtomicalsValidationError, auto_encode_bytes_elements, calculate_latest_state_from_mod_history, compact_to_location_id_bytes, format_name_type_candidates_to_rpc, format_name_type_candidates_to_rpc_for_subname, get_address_from_output_script, is_compact_atomical_id, location_id_bytes_to_compact, validate_merkle_proof_dmint, validate_rules_data
+from electrumx.lib.script2addr import get_address_from_output_script
+from electrumx.lib.util_atomicals import SUBREALM_MINT_PATH, AtomicalsValidationError, auto_encode_bytes_elements, calculate_latest_state_from_mod_history, compact_to_location_id_bytes, format_name_type_candidates_to_rpc, format_name_type_candidates_to_rpc_for_subname, is_compact_atomical_id, location_id_bytes_to_compact, validate_merkle_proof_dmint, validate_rules_data
 from electrumx.server.daemon import DaemonError
 
 
@@ -1893,17 +1894,15 @@ class HttpHandler(object):
             max_supply = atomical.get('$max_supply', 0)
             for holder in atomical.get("holders", [])[offset:offset+limit]:
                 percent = holder['holding'] / max_supply
-                address = get_address_from_output_script(holder['script'])
                 formatted_results.append({
                     "percent": percent,
-                    "address": address,
+                    "address": get_address_from_output_script(bytes.fromhex(holder['script'])),
                     "holding": holder["holding"]
                 })
         elif atomical["type"] == "NFT":
             for holder in atomical.get("holders", [])[offset:offset+limit]:
-                address = get_address_from_output_script(holder['script'])
                 formatted_results.append({
-                    "address": address,
+                    "address": get_address_from_output_script(bytes.fromhex(holder['script'])),
                     "holding": holder["holding"]
                 })
         return formatted_results

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -242,7 +242,7 @@ class SessionManager:
                     app.router.add_get('/proxy/blockchain.transaction.get_merkle', handler.transaction_merkle)
                     app.router.add_get('/proxy/blockchain.transaction.id_from_pos', handler.transaction_id_from_pos)
                     # app.router.add_get('/proxy/server.add_peer', handler.add_peer)
-                    app.router.add_get('/proxy/server.banner', handler.banner)
+                    # app.router.add_get('/proxy/server.banner', handler.banner)
                     app.router.add_get('/proxy/server.donation_address', handler.donation_address)
                     app.router.add_get('/proxy/server.features', handler.server_features_async)
                     app.router.add_get('/proxy/server.peers.subscribe', handler.peers_subscribe)


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


In the two previous merges, there was an oversight in my commits. I removed the existing `get_address_from_output_script method`, but I overlooked the import error in the committed `http-session`. I have now fixed this issue and also removed the `banner` method because it caused errors during testing. I will continue to maintain `http-session.
