### PR TITLE
Use a fixed `pylru` with to avoid key deletion exceptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiorpcX[ws]>=0.22.0,<0.23
 attrs
 plyvel
-pylru
+pylru @ git+https://github.com/atomicals-community/pylru@c9b47f0
 aiohttp>=3.3,<4
 cbor2
 websockets


### PR DESCRIPTION
`del self.table` could cause unexpected exception in multi-threading operations. The request updates the `pylru` instead of manipulating the project to fix the problem. Using a fixed ref to avoid dependency breakage in the future.

See https://github.com/atomicals-community/pylru/compare/master...atomicals-community:pylru:fix/del-key-from-table for the details.