### PR TITLE
Fix #119 Log file can not be rotate daily without restarting

### DIFF
--- a/electrumx_server
+++ b/electrumx_server
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import os
 import sys
+import logging.handlers
 
 from electrumx import Controller, Env
 from electrumx.lib.util import CompactFormatter, make_logger
@@ -26,7 +27,7 @@ def main():
         exist =os.path.exists(log_path)
         if not exist:
             os.makedirs(log_path)
-        handler = logging.FileHandler(log_path + "/electrumx.log")
+        handler = logging.handlers.WatchedFileHandler(log_path + "/electrumx.log")
     else:
         handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(CompactFormatter(log_fmt))


### PR DESCRIPTION
Fix https://github.com/atomicals/atomicals-electrumx/issues/119

use watchedfilehandler instead,logs can still be record in the same file even the file is changed or moved https://docs.python.org/3/library/logging.handlers.html#watchedfilehandler

<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->