### PR TITLE
🐛 Fix `get_subname_request_candidate_status`

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1646,7 +1646,7 @@ def get_subname_request_candidate_status(current_height, atomical_info, status, 
         }
 
     # It is still less than the minimum required blocks for the reveal delay
-    if current_height - current_candidate_atomical['commit_height'] > MINT_REALM_CONTAINER_TICKER_COMMIT_REVEAL_DELAY_BLOCKS:
+    if current_height - current_candidate_atomical['commit_height'] < MINT_REALM_CONTAINER_TICKER_COMMIT_REVEAL_DELAY_BLOCKS:
         # But some users perhaps made a payment nonetheless, we should show them a suitable status
         if payment_type == 'applicable_rule' and payment is not None:
             return {

--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1530,7 +1530,7 @@ def get_name_request_candidate_status(atomical_info, status, candidate_id, name_
     if not is_within_acceptable_blocks_for_name_reveal(mint_info['commit_height'], mint_info['reveal_location_height']):
         return {
             'status': 'expired_revealed_late',
-            'note': 'The maximum number of blocks between commit and reveal is ' + MAX_BLOCKS_STR + ' blocks'
+            'note': f'The maximum number of blocks between commit and reveal is {MAX_BLOCKS_STR} blocks.'
         }
     candidate_id_compact = None
     if candidate_id:
@@ -1543,14 +1543,15 @@ def get_name_request_candidate_status(atomical_info, status, candidate_id, name_
             return {
                 'status': 'verified',
                 'verified_atomical_id': candidate_id_compact,
-                'note': f'Successfully verified and claimed {name_type} for current Atomical'
+                'note': f'Successfully verified and claimed {name_type} for current Atomical.'
             }
         else:
             # The verified candidate is another one
             return {
                 'status': 'claimed_by_other',
                 'claimed_by_atomical_id': candidate_id_compact,
-                'note': f'Failed to claim {name_type} for current Atomical because it was claimed first by another Atomical'
+                'note': f'Failed to claim {name_type} for current Atomical '
+                        f'because it was claimed first by another Atomical.'
             }
     # If there is a pending candidate and it's not a subrealm or dmitem, then it must be a 'top level' name type
     # What that means is we can know for sure the status and not depend on payments or anything of that sort
@@ -1559,13 +1560,15 @@ def get_name_request_candidate_status(atomical_info, status, candidate_id, name_
             return {
                 'status': 'pending_candidate',
                 'pending_candidate_atomical_id': candidate_id_compact,
-                'note': f'The current Atomical is the leading candidate for the {name_type}. Wait the {MAX_BLOCKS_STR} blocks after commit to achieve confirmation'
+                'note': f'The current Atomical is the leading candidate for the {name_type}. '
+                        f'Wait the {MAX_BLOCKS_STR} blocks after commit to achieve confirmation.'
             }
         else:
             return {
                 'status': 'pending_claimed_by_other',
                 'pending_claimed_by_atomical_id': candidate_id_compact,
-                'note': f'Failed to claim {name_type} for current Atomical because it was claimed first by another Atomical'
+                'note': f'Failed to claim {name_type} for current Atomical '
+                        f'because it was claimed first by another Atomical.'
             }
     # The status is different or this is a subrealm or dmitem
     return {

--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1602,8 +1602,9 @@ def get_subname_request_candidate_status(current_height, atomical_info, status, 
         }
 
     payment_type = current_candidate_atomical.get('payment_type')
+    applicable_rule = current_candidate_atomical.get('applicable_rule')
     # Catch the scenario where it was not parent initiated, but there also was no valid applicable rule
-    if payment_type and current_candidate_atomical.get('applicable_rule') is None:
+    if payment_type and payment_type is not 'mint_initiated' and applicable_rule is None:
         return {
             'status': 'invalid_request_no_matched_applicable_rule'
         }

--- a/tests/lib/test_get_subname_request_candidate_status.py
+++ b/tests/lib/test_get_subname_request_candidate_status.py
@@ -54,7 +54,7 @@ def test_get_subname_request_candidate_status_verified_self():
     assert({
         'status': 'verified',
         'verified_atomical_id': subject_atomical_id_compact,
-        'note': 'Successfully verified and claimed realm for current Atomical'
+        'note': 'Successfully verified and claimed realm for current Atomical.'
     } == result)
 
 def test_get_subname_request_candidate_status_verified_claimed_by_other():
@@ -228,7 +228,7 @@ def test_get_subname_request_candidate_status_pending_awaiting_confirmations():
     assert({
         'status': 'pending_awaiting_confirmations',
         'pending_candidate_atomical_id': subject_atomical_id_compact2,
-        'note': 'Await 3 blocks has elapsed to verify'
+        'note': 'Await 3 blocks has elapsed to verify.'
     } == result)
 
 def test_get_subname_request_candidate_status_pending_awaiting_confirmations_for_payment_window():
@@ -291,7 +291,7 @@ def test_get_subname_request_candidate_status_pending_awaiting_confirmations_for
     assert({
         'status': 'pending_awaiting_confirmations_for_payment_window',
         'pending_candidate_atomical_id': subject_atomical_id_compact2,
-        'note': "Await until the 'make_payment_from_height' block height for the payment window to be open with status 'pending_awaiting_payment'"
+        'note': 'Await until the "make_payment_from_height" block height for the payment window to be open.'
     } == result)
 
 def test_get_subname_request_candidate_status_pending_awaiting_confirmations_payment_received_prematurely():
@@ -355,21 +355,21 @@ def test_get_subname_request_candidate_status_pending_awaiting_confirmations_pay
     assert({
         'status': 'pending_awaiting_confirmations_payment_received_prematurely',
         'pending_candidate_atomical_id': subject_atomical_id_compact,
-        'note': 'A payment was received, but the minimum delay of 3 blocks has not yet elapsed to declare a winner'
+        'note': 'The minimum delay of 3 blocks has not yet elapsed to declare a winner.'
     } == result)
 
     result = get_subname_request_candidate_status(890006, atomical_info, 'pending_awaiting_payment', subject_atomical_id, 'subrealm')
     assert({
         'status': 'pending_awaiting_confirmations_payment_received_prematurely',
         'pending_candidate_atomical_id': subject_atomical_id_compact,
-        'note': 'A payment was received, but the minimum delay of 3 blocks has not yet elapsed to declare a winner'
+        'note': 'The minimum delay of 3 blocks has not yet elapsed to declare a winner.'
     } == result)
 
     result = get_subname_request_candidate_status(890009, atomical_info, 'verified', subject_atomical_id, 'subrealm')
     assert({
         'status': 'verified',
         'verified_atomical_id': subject_atomical_id_compact,
-        'note': 'Successfully verified and claimed subrealm for current Atomical'
+        'note': 'Successfully verified and claimed subrealm for current Atomical.'
     } == result)
  
 
@@ -434,5 +434,5 @@ def test_get_subname_request_candidate_status_expired_payment_not_received():
     result = get_subname_request_candidate_status(890120, atomical_info, 'pending', subject_atomical_id, 'subrealm')
     assert({
         'status': 'expired_payment_not_received',
-        'note': "A valid payment was not received before the 'payment_due_no_later_than_height' limit"
+        'note': 'A valid payment was not received before the "payment_due_no_later_than_height" limit.'
     } == result)

--- a/tests/lib/test_get_subname_request_candidate_status.py
+++ b/tests/lib/test_get_subname_request_candidate_status.py
@@ -109,7 +109,7 @@ def test_get_subname_request_candidate_status_verified_claimed_by_other():
     assert({
         'status': 'claimed_by_other',
         'claimed_by_atomical_id': subject_atomical_id_compact2,
-        'note': 'Failed to claim for current Atomical because it was claimed first by another Atomical'
+        'note': 'Claimed first by another Atomical.'
     } == result)
 
 def test_get_subname_request_candidate_status_verified_pending_candidate():
@@ -164,7 +164,7 @@ def test_get_subname_request_candidate_status_verified_pending_candidate():
     assert({
         'status': 'pending_awaiting_confirmations',
         'pending_candidate_atomical_id': subject_atomical_id_compact2,
-        'note': 'Await 3 blocks has elapsed to verify'
+        'note': 'Await 3 blocks has elapsed to verify.'
     } == result)
 
 def test_get_subname_request_candidate_status_pending_awaiting_confirmations():


### PR DESCRIPTION
1. Fixes when the realm owner is minting its subrealm without following the rules, `invalid_request_no_matched_applicable_rule` will returned before it gets confirmed.
2. Reverts the problem when the block is still in the window of reveal delay, caused by #122.
3. Fixes corresponding tests.