### PR TITLE
fix name_len error

### DIFF
--- a/electrumx/server/db.py
+++ b/electrumx/server/db.py
@@ -1654,7 +1654,7 @@ class DB:
             if current_counter > offset + limit:
                 break
             # Use 4 bytes because of store name len as 4 bytes
-            name_len, = unpack_le_uint32_from(db_key[-10:-6])
+            name_len, = unpack_le_uint32_from(db_key[-12:-8])
             dmitem_name = db_key[len(db_prefix)]
             if entries_deduped.get(dmitem_name):
                 continue 
@@ -1712,7 +1712,7 @@ class DB:
             tx_numb = db_key[-8:]
             tx_num, = unpack_le_uint64(tx_numb)
             # Use 4 bytes because of store name len as 4 bytes
-            name_len, = unpack_le_uint32_from(db_key[-10:-6])
+            name_len, = unpack_le_uint32_from(db_key[-12:-8])
             db_key_prefix_len = len(db_key_prefix)
             entries.append({
                 'name': db_key[db_key_prefix_len : db_key_prefix_len + name_len].decode(), # Extract the name portion


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

https://github.com/atomicals/atomicals-electrumx/commit/9fea1e7604125c9fa78909a19d4ff5201f721d7c  will crash with
```
"message": "'utf-8' codec can't decode byte 0x88 in position 11: invalid start byte"
```