### PR TITLE
📌 Use fixed `merkletools`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ cbor2
 websockets
 regex
 krock32
-merkletools
+merkletools @ git+https://github.com/tierion/pymerkletools.git@f10d71e2cd529a833728e836dc301f9af502d0b0
 requests==2.31.0


### PR DESCRIPTION
The corresponding version stops installing `sha3` which avoids Python version-based setup issues.

*ref: https://github.com/Tierion/pymerkletools/commit/f10d71e2cd529a833728e836dc301f9af502d0b0*