### PR TITLE
fix next_start_out_idx

### DIFF
--- a/electrumx/lib/atomicals_blueprint_builder.py
+++ b/electrumx/lib/atomicals_blueprint_builder.py
@@ -61,11 +61,11 @@ def calculate_outputs_to_color_for_ft_atomical_ids(tx, ft_atomicals, sort_by_fif
         return None
         # return FtColoringSummary(potential_atomical_ids_to_output_idxs_map, fts_burned, not non_clean_output_slots, atomical_list)
     atomical_list = order_ft_inputs(ft_atomicals, sort_by_fifo)
-    next_start_out_idx = 0
     potential_atomical_ids_to_output_idxs_map = {}
     non_clean_output_slots = False
     fts_burned = {}
     for item in atomical_list:
+      next_start_out_idx = 0
       atomical_id = item.atomical_id
       # If a target exponent was provided, then use that instead
       use_exponent = item.max_exponent
@@ -597,7 +597,7 @@ class AtomicalsTransferBlueprintBuilder:
         input_value = ft_info['value']
         if sum_out_value and sum_out_value > input_value:
             atomical_id_compact = location_id_bytes_to_compact(atomical_id)
-            raise AtomicalsTransferBlueprintBuilderError(f'validate_ft_transfer_has_no_inflation: Fatal error the output sum of outputs is greater than input sum for Atomical: atomical_id={atomical_id_compact} input_value={input_value} sum_out_value={sum_out_value} {hash_to_hex_str(tx_hash)} ft_atomicals={ft_atomicals}')
+            raise AtomicalsTransferBlueprintBuilderError(f'validate_ft_transfer_has_no_inflation: Fatal error the output sum of outputs is greater than input sum for Atomical: atomical_id={atomical_id_compact} input_value={input_value} sum_out_value={sum_out_value} ft_atomicals={ft_atomicals}')
   
   def is_split_operation(self):
     return is_split_operation(self.operations_found_at_inputs)

--- a/tests/lib/test_atomicals_blueprint_builder.py
+++ b/tests/lib/test_atomicals_blueprint_builder.py
@@ -115,6 +115,7 @@ def test_spends_ft_multiple_valid_collapsed():
     subject_atomical_id2 = b"A\x03\x8f'\xe7\x85`l\xa0\xcc\x1e\xfd\x8e:\xa9\x12\xa1\\r\xd0o5\x9a\xeb\x05$=\xab+p\xa8V\x00\x00\x00\x00"
     
     tx, tx_hash = coin.DESERIALIZER(raw_tx, 0).read_tx_and_hash()
+    print(tx)
     atomicals_spent_at_inputs= {
         0: [{'atomical_id': subject_atomical_id, 'location_id': b'not_used', 'data': b'not_used', 'data_ex': {'value': 1000, 'exponent': 0}}], 
         1: [{'atomical_id': subject_atomical_id2, 'location_id': b'not_used', 'data': b'not_used', 'data_ex': {'value': 3000, 'exponent': 0}}], 
@@ -143,7 +144,7 @@ def test_spends_ft_multiple_valid_collapsed():
     assert(len(ft_output_blueprint.outputs) == 1)
     assert(ft_output_blueprint.first_atomical_id == subject_atomical_id)
     assert(len(ft_output_blueprint.fts_burned) == 0)
-    assert(ft_output_blueprint.cleanly_assigned == False)
+    assert(ft_output_blueprint.cleanly_assigned == True)
     assert(blueprint_builder.get_are_fts_burned() == False)
  
 def test_spends_ft_single_burned_under():

--- a/tests/lib/test_atomicals_blueprint_builder.py
+++ b/tests/lib/test_atomicals_blueprint_builder.py
@@ -115,7 +115,6 @@ def test_spends_ft_multiple_valid_collapsed():
     subject_atomical_id2 = b"A\x03\x8f'\xe7\x85`l\xa0\xcc\x1e\xfd\x8e:\xa9\x12\xa1\\r\xd0o5\x9a\xeb\x05$=\xab+p\xa8V\x00\x00\x00\x00"
     
     tx, tx_hash = coin.DESERIALIZER(raw_tx, 0).read_tx_and_hash()
-    print(tx)
     atomicals_spent_at_inputs= {
         0: [{'atomical_id': subject_atomical_id, 'location_id': b'not_used', 'data': b'not_used', 'data_ex': {'value': 1000, 'exponent': 0}}], 
         1: [{'atomical_id': subject_atomical_id2, 'location_id': b'not_used', 'data': b'not_used', 'data_ex': {'value': 3000, 'exponent': 0}}], 


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

According to https://docs.atomicals.xyz/arc20-tokens/normal-transfer-rules.
when a uxto have two or other tickers. it should try to color from 0, Is that right?