### PR TITLE
🚸 Add `python-dotenv` to automatically load environments

### DIFF
--- a/electrumx_compact_history
+++ b/electrumx_compact_history
@@ -37,8 +37,11 @@ import sys
 import traceback
 from os import environ
 
+from dotenv import load_dotenv
 from electrumx import Env
 from electrumx.server.db import DB
+
+load_dotenv()
 
 
 async def compact_history():

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -16,8 +16,11 @@ import json
 import sys
 from os import environ
 
+from dotenv import load_dotenv
 from aiorpcx import timeout_after, connect_rs
 import electrumx.lib.text as text
+
+load_dotenv()
 
 
 simple_commands = {

--- a/electrumx_server
+++ b/electrumx_server
@@ -15,8 +15,11 @@ import os
 import sys
 import logging.handlers
 
+from dotenv import load_dotenv
 from electrumx import Controller, Env
 from electrumx.lib.util import CompactFormatter, make_logger
+
+load_dotenv()
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ regex
 krock32
 merkletools @ git+https://github.com/tierion/pymerkletools.git@f10d71e2cd529a833728e836dc301f9af502d0b0
 requests==2.31.0
+python-dotenv
 
 # For LevelDB
 plyvel


### PR DESCRIPTION
You don't need to run `source .env` manually and the server can be debugged easily.