### PR TITLE
⚡️ Improve subscribe headers

### DIFF
--- a/electrumx/server/http_session.py
+++ b/electrumx/server/http_session.py
@@ -96,6 +96,7 @@ class HttpHandler(object):
         # self.transport = transport
         self.logger = util.class_logger(__name__, self.__class__.__name__)
         self.session_mgr = session_mgr
+        self.subscribe_headers = False
         self.db = db
         self.mempool = mempool
         self.peer_mgr = peer_mgr

--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1338,8 +1338,9 @@ class ElectrumX(SessionBase):
 
     async def headers_subscribe(self):
         '''Subscribe to get raw headers of new blocks.'''
-        self.subscribe_headers = True
-        self.bump_cost(0.25)
+        if not self.subscribe_headers:
+            self.subscribe_headers = True
+            self.bump_cost(0.25)
         return await self.subscribe_headers_result()
 
     async def add_peer(self, features):


### PR DESCRIPTION
- Avoid extra `bump_cost` when making duplicate subscriptions.
- Define the missing `subscribe_headers` for the HTTP session, which recovers the functionality.