### PR TITLE
⚡️ Clear all history caches when block height changed

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1046,11 +1046,10 @@ class SessionManager:
         height_changed = height != self.notified_height
         if height_changed:
             await self._refresh_hsub_results(height)
-            # Invalidate our history cache for touched hashXs
-            cache = self._history_cache
+            # Invalidate all history caches since they rely on block heights
+            self._history_cache.clear()
+            # Invalidate our op cache for touched hashXs
             op_cache = self._history_op_cache
-            for hashX in set(cache).intersection(touched):
-                del cache[hashX]
             for hashX in set(op_cache).intersection(touched):
                 op_cache.pop(hashX, None)
                 self.logger.info(f"refresh op cache {self.notified_height}")


### PR DESCRIPTION
Histories are changed due to blocks. Clearing all caches will result in correct & accurate histories.