### PR TITLE
fix CBORTag

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1282,7 +1282,8 @@ def encode_tx_hash_hex(state):
         cloned_state[encode_tx_hash_hex(key)] = encode_tx_hash_hex(value)
     return cloned_state 
 
-# Auto detect any bytes data and encoded it
+
+# Auto encodes data into structured bytes data.
 def auto_encode_bytes_elements(state):
     if isinstance(state, bytes):
         return {
@@ -1290,23 +1291,23 @@ def auto_encode_bytes_elements(state):
             '$len': sys.getsizeof(state),
             '$auto': True
         }
-    
+
     if isinstance(state, CBORTag):
-        return dumps(state)
-    
-    if not isinstance(state, dict) and not isinstance(state, list):
-        return state 
-    
+        dumped_bytes = dumps(state)
+        return auto_encode_bytes_elements(dumped_bytes)
+
     if isinstance(state, list):
         reformatted_list = []
         for item in state:
             reformatted_list.append(auto_encode_bytes_elements(item))
         return reformatted_list
-    
-    for key, value in state.items():
-        state[key] = auto_encode_bytes_elements(value)
-    return state 
- 
+
+    if isinstance(state, dict):
+        for key, value in state.items():
+            state[key] = auto_encode_bytes_elements(value)
+
+    return state
+
 
 # Base atomical commit to reveal delay allowed
 def is_within_acceptable_blocks_for_general_reveal(commit_height, reveal_location_height):

--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -39,7 +39,7 @@ import krock32
 import pickle
 import math
 from electrumx.lib.hash import sha256, double_sha256
-from cbor2 import dumps, loads, CBORDecodeError
+from cbor2 import dumps, loads, CBORDecodeError, CBORTag
 from collections.abc import Mapping
 from functools import reduce
 from merkletools import MerkleTools
@@ -1290,6 +1290,10 @@ def auto_encode_bytes_elements(state):
             '$len': sys.getsizeof(state),
             '$auto': True
         }
+    
+    if isinstance(state, CBORTag):
+        return dumps(state)
+    
     if not isinstance(state, dict) and not isinstance(state, list):
         return state 
     
@@ -1297,8 +1301,8 @@ def auto_encode_bytes_elements(state):
         reformatted_list = []
         for item in state:
             reformatted_list.append(auto_encode_bytes_elements(item))
-        return reformatted_list 
-
+        return reformatted_list
+    
     for key, value in state.items():
         state[key] = auto_encode_bytes_elements(value)
     return state 

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -1619,7 +1619,7 @@ class BlockProcessor:
         # Make a deep copy of the data payload and remove the reserved sections
         copied_data_state = {}
         for k, v in data_payload.items():
-            if k != "args":
+            if k != 'args':
                 copied_data_state[k] = v
         init_payload_bytes = dumps(copied_data_state)
         op_struct = {

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -1617,9 +1617,10 @@ class BlockProcessor:
         height = mint_info['reveal_location_height']
 
         # Make a deep copy of the data payload and remove the reserved sections
-        copied_data_state = copy.deepcopy(data_payload)
-        # Remove any of the reserved sections
-        copied_data_state.pop('args', None)
+        copied_data_state = {}
+        for k, v in data_payload.items():
+            if k != "args":
+                copied_data_state[k] = v
         init_payload_bytes = dumps(copied_data_state)
         op_struct = {
             'op': 'mod',

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2464,78 +2464,112 @@ class BlockProcessor:
 
     # Populate the specific subrealm request type information
     def populate_subrealm_subtype_specific_fields(self, atomical):
-        # Check if the effective subrealm is for the current atomical and also resolve it's parent
+        # Check if the effective subrealm is for the current atomical and also resolve its parent.
         request_subrealm = atomical['mint_info'].get('$request_subrealm')
-        if not request_subrealm: 
+        if not request_subrealm:
             return None, None
-        pid_compact = atomical['mint_info']['$parent_realm'] 
-        pid = compact_to_location_id_bytes(pid_compact)  
+        pid_compact = atomical['mint_info']['$parent_realm']
+        pid = compact_to_location_id_bytes(pid_compact)
         height = self.height
         status, candidate_id, raw_candidate_entries = self.get_effective_subrealm(pid, request_subrealm, height)
-        atomical['subtype'] = 'request_subrealm' # Will change to 'subrealm' if it is found to be valid
+        atomical['subtype'] = 'request_subrealm'  # Will change to 'subrealm' if it is found to be valid
         # Populate the requested full realm name
         self.populate_request_full_realm_name(atomical, pid, request_subrealm)
-        # Build the applicable rule set mapping of atomical_id to the rule that will need to be matched and payment made 
-        # We use this information to display to each candidate what rule would apply to their mint and how much to pay and by which block height
-        # they must submit their payment (assuming they are the leading candidate)
+        # Build the applicable rule set mapping of atomical_id to the rule that will need to be matched and paid.
+        # We use this information to display to each candidate what rule would apply to their mint
+        # and how much to pay and by which block height they must submit their payment
+        # (assuming they are the leading candidate)
         applicable_rule_map = self.build_applicable_rule_map(raw_candidate_entries, pid, request_subrealm)
-        self.logger.info(f'populate_subrealm_subtype_specific_fields_applicable_rule_map {applicable_rule_map} raw_candidate_entries={raw_candidate_entries}')
-        atomical['$subrealm_candidates'] = format_name_type_candidates_to_rpc_for_subname(raw_candidate_entries, applicable_rule_map)
-        atomical['$request_subrealm_status'] = get_subname_request_candidate_status(self.height, atomical, status, candidate_id, 'subrealm') 
-        # Populate the request specific fields
+        self.logger.info(
+            f'populate_subrealm_subtype_specific_fields_applicable_rule_map {applicable_rule_map} '
+            f'raw_candidate_entries={raw_candidate_entries}',
+        )
+        atomical['$subrealm_candidates'] = format_name_type_candidates_to_rpc_for_subname(
+            raw_candidate_entries,
+            applicable_rule_map,
+        )
+        atomical['$request_subrealm_status'] = get_subname_request_candidate_status(
+            self.height,
+            atomical,
+            status,
+            candidate_id,
+            'subrealm',
+        )
+        # Populate the request specific fields.
         atomical['$request_subrealm'] = atomical['mint_info'].get('$request_subrealm')
-        atomical['$parent_realm'] = atomical['mint_info'].get('$parent_realm')
-
+        atomical['$parent_realm'] = pid_compact
+        # Resolve the parent realm to get the parent realm path and construct the `full_realm_name`.
+        parent_realm = self.get_base_mint_info_by_atomical_id(pid)
+        if not parent_realm:
+            atomical_id = atomical['mint_info']['id']
+            raise IndexError(
+                f'populate_subrealm_subtype_specific_fields: '
+                f'parent realm not found atomical_id={atomical_id}, '
+                f'parent_realm={parent_realm}',
+            )
+        self.logger.info(f'populate_subrealm_subtype_specific_fields: parent_realm={parent_realm}')
+        # The parent full realm name may not be populated if it's still in the mempool,
+        # or it's not settled realm request yet. Therefore, check to make sure it exists
+        # before we can populate this subrealm's full realm name.
+        if parent_realm.get('$full_realm_name'):
+            parent_realm_name = parent_realm['$full_realm_name']
+            atomical['$full_realm_name'] = f'{parent_realm_name}.{request_subrealm}'
         if status == 'verified' and candidate_id == atomical['atomical_id']:
             atomical['subtype'] = 'subrealm'
             atomical['$subrealm'] = request_subrealm
             atomical['$parent_realm'] = pid_compact
-            # Resolve the parent realm to get the parent realm path and construct the full_realm_name
-            parent_realm = self.get_base_mint_info_by_atomical_id(pid)
-            if not parent_realm:
-                atomical_id = atomical['mint_info']['id']
-                raise IndexError(f'populate_subrealm_subtype_specific_fields: parent realm not found atomical_id={atomical_id}, parent_realm={parent_realm}')
-            # The parent full realm name my not be populated if it's still in the mempool or it's not settled realm request yet
-            # Therefore check to make sure it exists before we can populate this subrealms full realm name 
-            self.logger.info(f'populate_subrealm_subtype_specific_fields: parent_realm={parent_realm}')
-            if parent_realm.get('$full_realm_name'):
-                atomical['$full_realm_name'] = parent_realm['$full_realm_name'] + '.' + request_subrealm
             return request_subrealm, True
         return request_subrealm, False
 
     # Populate the specific dmitem request type information
     def populate_dmitem_subtype_specific_fields(self, atomical):
-        # Check if the effective subrealm is for the current atomical and also resolve it's parent
+        # Check if the effective dmitem is for the current atomical and also resolve its parent.
         request_dmitem = atomical['mint_info'].get('$request_dmitem')
-        if not request_dmitem: 
+        if not request_dmitem:
             return None, None
-        pid_compact = atomical['mint_info']['$parent_container'] 
-        pid = compact_to_location_id_bytes(pid_compact)  
+        pid_compact = atomical['mint_info']['$parent_container']
+        pid = compact_to_location_id_bytes(pid_compact)
         height = self.height
         status, candidate_id, raw_candidate_entries = self.get_effective_dmitem(pid, request_dmitem, height)
-        atomical['subtype'] = 'request_dmitem' # Will change to 'subrealm' if it is found to be valid
-        # Populate the requested full realm name
-        # self.populate_request_full_realm_name(atomical, pid, request_subrealm)
-        # Build the applicable rule set mapping of atomical_id to the rule that will need to be matched and payment made 
-        # We use this information to display to each candidate what rule would apply to their mint and how much to pay and by which block height
-        # they must submit their payment (assuming they are the leading candidate)
+        atomical['subtype'] = 'request_dmitem'  # Will change to 'dmitem' if it is found to be valid.
+        # Build the applicable rule set mapping of atomical_id to the rule that will need to be matched and paid.
+        # We use this information to display to each candidate what rule would apply to their mint
+        # and how much to pay and by which block height they must submit their payment
+        # (assuming they are the leading candidate).
         applicable_rule_map = self.build_applicable_rule_map_dmitem(raw_candidate_entries, pid, request_dmitem)
-        self.logger.info(f'populate_dmitem_subtype_specific_fields build_applicable_rule_map_dmitem applicable_rule_map={applicable_rule_map} raw_candidate_entries={raw_candidate_entries}')
-        atomical['$dmitem_candidates'] = format_name_type_candidates_to_rpc_for_subname(raw_candidate_entries, applicable_rule_map)
-        atomical['$request_dmitem_status'] = get_subname_request_candidate_status(self.height, atomical, status, candidate_id, 'dmitem') 
-        # Populate the request specific fields
+        self.logger.info(
+            f'populate_dmitem_subtype_specific_fields '
+            f'build_applicable_rule_map_dmitem '
+            f'applicable_rule_map={applicable_rule_map} '
+            f'raw_candidate_entries={raw_candidate_entries}',
+        )
+        atomical['$dmitem_candidates'] = format_name_type_candidates_to_rpc_for_subname(
+            raw_candidate_entries,
+            applicable_rule_map,
+        )
+        atomical['$request_dmitem_status'] = get_subname_request_candidate_status(
+            self.height,
+            atomical,
+            status,
+            candidate_id,
+            'dmitem',
+        )
+        # Populate the request specific fields.
         atomical['$request_dmitem'] = atomical['mint_info'].get('$request_dmitem')
-        atomical['$parent_container'] = atomical['mint_info'].get('$parent_container')
+        atomical['$parent_container'] = pid_compact
+        # Resolve the parent to get the parent path and construct the `parent_container_name`.
+        parent_container = self.get_base_mint_info_by_atomical_id(pid)
+        if not parent_container:
+            atomical_id = atomical['mint_info']['id']
+            raise IndexError(
+                f'populate_dmitem_subtype_specific_fields: '
+                f'parent container not found atomical_id={atomical_id}, '
+                f'parent_container={parent_container}',
+            )
+        atomical['$parent_container_name'] = parent_container['$container']
         if status == 'verified' and candidate_id == atomical['atomical_id']:
             atomical['subtype'] = 'dmitem'
             atomical['$dmitem'] = request_dmitem
-            atomical['$parent_container'] = pid_compact
-            # Resolve the parent to get the parent path and construct the full_realm_name
-            parent_container = self.get_base_mint_info_by_atomical_id(pid)
-            if not parent_container:
-                atomical_id = atomical['mint_info']['id']
-                raise IndexError(f'populate_dmitem_subtype_specific_fields: parent container not found atomical_id={atomical_id}, parent_container={parent_container}')
-            atomical['$parent_container_name'] = parent_container['$container']
             return request_dmitem, True
         return request_dmitem, False
 

--- a/electrumx/server/http_session.py
+++ b/electrumx/server/http_session.py
@@ -1571,6 +1571,8 @@ class HttpHandler(object):
         found_atomical_id = None
         if status == 'verified':
             found_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
 
         return_result = {
             'status': status,
@@ -1601,6 +1603,8 @@ class HttpHandler(object):
         found_atomical_id = None
         if status == 'verified':
             found_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
 
         return_result = {
             'status': status,
@@ -1631,6 +1635,8 @@ class HttpHandler(object):
         found_atomical_id = None
         if status == 'verified':
             found_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
 
         return_result = {
             'status': status,
@@ -1659,6 +1665,8 @@ class HttpHandler(object):
         found_atomical_id = None
         if status == 'verified':
             found_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
 
         return_result = {
             'status': status,
@@ -1685,6 +1693,8 @@ class HttpHandler(object):
         found_atomical_id = None
         if status == 'verified':
             found_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
 
         return_result = {
             'status': status,
@@ -1715,10 +1725,14 @@ class HttpHandler(object):
         status, candidate_atomical_id, all_entries = self.session_mgr.bp.get_effective_dmitem(found_atomical_id, item_name, height)
         found_item_atomical_id = None
         formatted_entries = format_name_type_candidates_to_rpc(all_entries, self.session_mgr.bp.build_atomical_id_to_candidate_map(all_entries))
+
         if candidate_atomical_id:
             candidate_atomical_id = location_id_bytes_to_compact(candidate_atomical_id)
         if status == 'verified':
             found_item_atomical_id = candidate_atomical_id
+        if status is None:
+            formatted_entries = []
+
         return_result = {
             'status': status, 
             'candidate_atomical_id': candidate_atomical_id, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,3 @@ python-dotenv
 # For LevelDB
 plyvel
 
-# For RocksDB
-Cython
-rocksdb @ git+https://github.com/jansegre/python-rocksdb@6177a68

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     extras_require={
         'dev': ['objgraph'],
         'rapidjson': ['python-rapidjson>=0.4.1,<2.0'],
-        'rocksdb': ['python-rocksdb>=0.6.9'],
+        'rocksdb': ['Cython', 'rocksdb @ git+https://github.com/jansegre/python-rocksdb@6177a68'],
         'ujson': ['ujson>=2.0.0,<4.0.0'],
         'uvloop': ['uvloop>=0.14'],
         # For various coins


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


In testnet block processor,  We found some invalid payload.
```
...  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/electrumx/lib/server_base.py", line 129, in run
    await server_task
  File "/Users/Documents/atomicals-electrumx/electrumx/lib/server_base.py", line 102, in serve
    await self.serve(shutdown_event)
  File "/Users/Documents/atomicals-electrumx/electrumx/server/controller.py", line 134, in serve
    async with OldTaskGroup() as group:
  File "/Users/Documents/atomicals-electrumx/venv/lib/python3.12/site-packages/aiorpcx/curio.py", line 297, in aexit
    await self.join()
  File "/Users/Documents/atomicals-electrumx/electrumx/lib/util.py", line 370, in join
    task.result()
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 3586, in fetch_and_process_blocks
    async with OldTaskGroup() as group:
  File "/Users/Documents/atomicals-electrumx/venv/lib/python3.12/site-packages/aiorpcx/curio.py", line 297, in aexit
    await self.join()
  File "/Users/Documents/atomicals-electrumx/electrumx/lib/util.py", line 370, in join
    task.result()
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 3548, in _process_prefetched_blocks
    await self.check_and_advance_blocks(blocks)
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 330, in check_and_advance_blocks
    await self.run_in_thread_with_lock(self.advance_blocks, blocks)
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 313, in run_in_thread_with_lock
    return await asyncio.shield(run_in_thread_locked())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 312, in run_in_thread_locked
    return await run_in_thread(func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/venv/lib/python3.12/site-packages/aiorpcx/curio.py", line 57, in run_in_thread
    return await get_event_loop().run_in_executor(None, func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 515, in advance_blocks
    undo_info, atomicals_undo_info = self.advance_txs(block.transactions, is_unspendable, block.header, height)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 2972, in advance_txs
    created_atomical_id = self.create_or_delete_atomical(atomicals_operations_found_at_inputs, atomicals_spent_at_inputs, header, height, tx_num, atomical_num, tx, tx_hash, False)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 1568, in create_or_delete_atomical
    self.put_or_delete_init_state_updates(mint_info, operations_found_at_inputs['payload'], Delete)
  File "/Users/Documents/atomicals-electrumx/electrumx/server/block_processor.py", line 1620, in put_or_delete_init_state_updates
    copied_data_state = copy.deepcopy(data_payload)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/copy.py", line 151, in deepcopy
    rv = reductor(4)
         ^^^^^^^^^^^
TypeError: cannot pickle '_cbor2.CBORTag' object
...
```

Deepcopy cannot pickle '_cbor2.CBORTag' object, so we change deepcopy to a new dict.
And we also change auto_encode_bytes_elements.
