### PR TITLE
🐛 Avoid parent container `KeyError`

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2567,7 +2567,11 @@ class BlockProcessor:
                 f'parent container not found atomical_id={atomical_id}, '
                 f'parent_container={parent_container}',
             )
-        atomical['$parent_container_name'] = parent_container['$container']
+        # The parent container name may not be populated if it's still in the mempool,
+        # or it's not settled realm request yet. Therefore, check to make sure it exists
+        # before we can populate this dmitem's container name.
+        if parent_container.get('$container'):
+            atomical['$parent_container_name'] = parent_container['$container']
         if status == 'verified' and candidate_id == atomical['atomical_id']:
             atomical['subtype'] = 'dmitem'
             atomical['$dmitem'] = request_dmitem


### PR DESCRIPTION
```console
2024-04-17 15:43:44,250ERROR:ElectrumX:[0] exception handling Request('blockchain.atomicals.list', [40, -1, 0])
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/aiorpcX-0.22.1-py3.10.egg/aiorpcx/session.py", line 481, in _throttled_request
    result = await self.handle_request(request)
  File "/data/atomicals-electrumx/electrumx/server/session.py", line 1212, in handle_request
    return await coro
  File "/data/atomicals-electrumx/electrumx/server/session.py", line 1594, in atomicals_list
    return await self.atomicals_list_get(offset, limit, asc)
  File "/data/atomicals-electrumx/electrumx/server/session.py", line 1536, in atomicals_list_get
    atomical = await self.atomical_id_get(location_id_bytes_to_compact(atomical_id))
  File "/data/atomicals-electrumx/electrumx/server/session.py", line 1438, in atomical_id_get
    atomical = await self.session_mgr.bp.get_base_mint_info_rpc_format_by_atomical_id(atomical_id)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2055, in get_base_mint_info_rpc_format_by_atomical_id
    atomical_result = await self.get_base_mint_info_by_atomical_id_async(atomical_id)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2328, in get_base_mint_info_by_atomical_id_async
    return await run_in_thread(read_atomical)
  File "/usr/local/lib/python3.10/dist-packages/aiorpcX-0.22.1-py3.10.egg/aiorpcx/curio.py", line 57, in run_in_thread
    return await get_event_loop().run_in_executor(None, func, *args)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2327, in read_atomical
    return that.get_base_mint_info_by_atomical_id(atomical_id)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2317, in get_base_mint_info_by_atomical_id
    self.populate_extended_atomical_subtype_info(atomical)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2625, in populate_extended_atomical_subtype_info
    self.populate_dmitem_subtype_specific_fields(atomical)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 2570, in populate_dmitem_subtype_specific_fields
    atomical['$parent_container_name'] = parent_container['$container']
KeyError: '$container'
```