### PR TITLE
Custom colored

### DIFF
--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -1069,7 +1069,8 @@ def parse_operation_from_script(script, n):
             atom_op_decoded = 'x'  # extract - move atomical to 0'th output
         elif atom_op == "0179":
             atom_op_decoded = 'y'  # split - 
-
+        elif atom_op == "017a":
+            atom_op_decoded = 'z'
         if atom_op_decoded:
             return atom_op_decoded, parse_atomicals_data_definition_operation(script, n + one_letter_op_len)
     
@@ -1511,6 +1512,9 @@ def is_splat_operation(operations_found_at_inputs):
 
 def is_split_operation(operations_found_at_inputs):
     return operations_found_at_inputs and operations_found_at_inputs.get('op') == 'y' and operations_found_at_inputs.get('input_index') == 0
+
+def is_custom_colored_operation(operations_found_at_inputs):
+    return operations_found_at_inputs and operations_found_at_inputs.get('op') == 'z' and operations_found_at_inputs.get('input_index') == 0
 
 def is_seal_operation(operations_found_at_inputs):
     return operations_found_at_inputs and operations_found_at_inputs.get('op') == 'sl' and operations_found_at_inputs.get('input_index') == 0

--- a/electrumx/server/http_session.py
+++ b/electrumx/server/http_session.py
@@ -1904,6 +1904,8 @@ class HttpHandler(object):
             res["op"] = "splat"
         elif operation_found_at_inputs and operation_found_at_inputs["op"] == "y":
             res["op"] = "split"
+        elif operation_found_at_inputs and operation_found_at_inputs["op"] == "z":
+            res["op"] = "custom-color"
         elif operation_found_at_inputs and operation_found_at_inputs["op"] == "evt":
             res["op"] = "evt"
         elif operation_found_at_inputs and operation_found_at_inputs["op"] == "mod":


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

Define a "z" op, for custom color outputs.

Payload like this:
```
    operation_found_at_inputs["payload"] = {
        "9527efa43262636d8f5917fc763fbdd09333e4b387afd6d4ed7a905a127b27b4i0": {
            "0": 200,
            "1": 300,
        },
        "8888e25790cc118773c8590522e1cab2ccc073a9375b238aaf9aadb13a764a13i0": {
            "2": 8000,
            "4": 8000,
        }
    }
``` 
We can set any int in every outputs. and custom colored ft.
Be careful, If your payload is flawed, it may lead to unnecessary burned.