### PR TITLE
make LOG_LEVEL env compatible

### DIFF
--- a/electrumx_server
+++ b/electrumx_server
@@ -25,7 +25,7 @@ load_dotenv()
 def main():
     '''Set up logging and run the server.'''
     log_fmt = Env.default('LOG_FORMAT', '%(levelname)s:%(name)s:%(message)s')
-    log_level = Env.default('LOG_LEVEL', 'INFO')
+    log_level = Env.default('LOG_LEVEL', 'INFO').upper()
     log_path = Env.default('LOG_PATH', None)
     if log_path:
         exist =os.path.exists(log_path)


### PR DESCRIPTION
The PR #171 made `electrumx_server` read `LOG_LEVEL` from env.

Previously we could use lowercase `info` because it would automatically convert to uppercase `INFO`. https://github.com/atomicals/atomicals-electrumx/blob/dd15e23099812e21894e46d76d5de0e897bc1d5d/electrumx/server/env.py#L73.

When upgrading our RPC endpoint (https://ep.nextdao.xyz/proxy/health) to v1.4.0, it started failed.