### PR TITLE
🐛 Fix payments recognition during advances

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2208,7 +2208,7 @@ class BlockProcessor:
     # Get the atomical details base info
     # Does not retrieve the active b'a' locations in this method because there could be many thousands (in the case of FTs)
     # Another method is provided to layer on the active location and gives the user control over whether to retrieve them
-    def get_base_mint_info_by_atomical_id(self, atomical_id, height: int = None):
+    def get_base_mint_info_by_atomical_id(self, atomical_id, height: Optional[int] = None):
         height = height if height else self.height
         init_mint_info = self.get_atomicals_id_mint_info(atomical_id, True)
         if not init_mint_info:
@@ -2396,7 +2396,7 @@ class BlockProcessor:
         return atomical_id_to_candidates_map
         
     # Populate the requested full realm name to provide context for a subrealm request
-    def populate_request_full_realm_name(self, atomical, pid, request_subrealm, height: int = None):
+    def populate_request_full_realm_name(self, atomical, pid, request_subrealm, height: Optional[int] = None):
         # Resolve the parent realm to get the parent realm path and construct the full_realm_name
         parent_realm = self.get_base_mint_info_by_atomical_id(pid, height)
         if not parent_realm:

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -747,7 +747,7 @@ class BlockProcessor:
             self.logger.info(f'get_expected_dmitem_payment_info: parent_container_id_compact not string or compact atomical id {location_id_bytes_to_compact(found_atomical_id_for_potential_dmitem)} parent_container_id_compact={parent_container_id_compact}')
             return None, None, None, None
         # We have a validated potential parent id, now look it up to see if the parent is a valid atomical
-        found_parent_mint_info = self.get_base_mint_info_by_atomical_id(parent_container_id, with_cache=False, height=current_height)
+        found_parent_mint_info = self.get_base_mint_info_by_atomical_id(parent_container_id, height=current_height)
         if not found_parent_mint_info:
             self.logger.info(f'get_expected_dmitem_payment_info: not found_parent_mint_info found_atomical_id_for_potential_dmitem={location_id_bytes_to_compact(found_atomical_id_for_potential_dmitem)} parent_container_id_compact={parent_container_id_compact} found_atomical_mint_info_for_potential_dmitem={found_atomical_mint_info_for_potential_dmitem}')
             return None, None, None, None
@@ -2208,8 +2208,8 @@ class BlockProcessor:
     # Get the atomical details base info
     # Does not retrieve the active b'a' locations in this method because there could be many thousands (in the case of FTs)
     # Another method is provided to layer on the active location and gives the user control over whether to retrieve them
-    def get_base_mint_info_by_atomical_id(self, atomical_id, with_cache: bool = True, height: int = None):
-        init_mint_info = self.get_atomicals_id_mint_info(atomical_id, with_cache)
+    def get_base_mint_info_by_atomical_id(self, atomical_id, height: int = None):
+        init_mint_info = self.get_atomicals_id_mint_info(atomical_id, True)
         if not init_mint_info:
             return None
         atomical_number = init_mint_info['number']

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -3009,18 +3009,18 @@ class BlockProcessor:
                 # in one and the same tx as making a payment. It's not advisable to do so, but it's a valid possibility
 
                 # Check if there were any payments for subrealms in tx
-                payment_tx_hash = self.create_or_delete_subname_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_operations_found_at_inputs, atomicals_spent_at_inputs,  b'spay', self.subrealmpay_data_cache, self.get_expected_subrealm_payment_info, False)
-                if payment_tx_hash:
+                subrealm_payment_tx_hash = self.create_or_delete_subname_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_operations_found_at_inputs, atomicals_spent_at_inputs,  b'spay', self.subrealmpay_data_cache, self.get_expected_subrealm_payment_info, False)
+                if subrealm_payment_tx_hash:
                     self.logger.info(f'advance_txs: found valid subrealm payment create_or_delete_subname_payment_output_if_valid {hash_to_hex_str(tx_hash)}')
-                    append_hashX(double_sha256(payment_tx_hash))
+                    append_hashX(double_sha256(subrealm_payment_tx_hash))
                     self.put_op_data(tx_num, tx_hash, "payment-subrealm")
                     has_at_least_one_valid_atomicals_operation = True
 
                 # Check if there were any payments for dmitems in tx
-                payment_tx_hash = self.create_or_delete_subname_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_operations_found_at_inputs, atomicals_spent_at_inputs,  b'dmpay', self.dmpay_data_cache, self.get_expected_dmitem_payment_info, False)
-                if payment_tx_hash:
+                dmitem_payment_tx_hash = self.create_or_delete_subname_payment_output_if_valid(tx_hash, tx, tx_num, height, atomicals_operations_found_at_inputs, atomicals_spent_at_inputs,  b'dmpay', self.dmpay_data_cache, self.get_expected_dmitem_payment_info, False)
+                if dmitem_payment_tx_hash:
                     self.logger.info(f'advance_txs: found valid dmitem payment create_or_delete_subname_payment_output_if_valid {hash_to_hex_str(tx_hash)}')
-                    append_hashX(double_sha256(payment_tx_hash))
+                    append_hashX(double_sha256(dmitem_payment_tx_hash))
                     self.put_op_data(tx_num, tx_hash, "payment-dmitem")
                     has_at_least_one_valid_atomicals_operation = True
  


### PR DESCRIPTION
The verified status of an Atomical relies on the reveal window. The height in the query is the latest advanced block height rather than the processing height, which leads to an incorrect verified status for the container and realm.

The issue used to produce incorrect block hashes, probably incorrect Atomicals assets.

See height:`tx` records below for more details on the testnet:
- 2532818: `b756276cdd06cc188c0266010c9fbf3e416089967a898275ca2909b93081f3ce`
- 2569512: `a98015464f0859b5f56011b4c0fb8911a83cac61cd77730744447919c79471a0`