### PR TITLE
Fix blockchain.atomicals.transaction bug

### DIFF
--- a/electrumx/server/session.py
+++ b/electrumx/server/session.py
@@ -1062,7 +1062,8 @@ class SessionManager:
             tx_hash,
             tx,
             self.bp.get_atomicals_id_mint_info,
-            True
+            self.bp.is_dmint_activated(height),
+            self.bp.is_custom_coloring_activated(height),
         )
         is_burned = blueprint_builder.are_fts_burned
         is_cleanly_assigned = blueprint_builder.cleanly_assigned
@@ -1170,7 +1171,7 @@ class SessionManager:
                         "atomical_id": compact_atomical_id,
                         "type": "FT",
                         "index": k,
-                        "value": output_ft.satvalue
+                        "value": output_ft.sat_value
                     }
                     if k not in res["transfers"]["outputs"]:
                         res["transfers"]["outputs"][k] = [ft_data]


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

```
WARNING:SessionManager:Request <Request POST /proxy/blockchain.atomicals.transaction > has failed with exception: TypeError("AtomicalsTransferBlueprintBuilder.__init__() missing 1 required positional argument: 'is_custom_coloring_activated'")
WARNING:SessionManager:Traceback (most recent call last):
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_middleware.py", line 61, in middleware_handler
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_middleware.py", line 115, in middleware_handler
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_session.py", line 1792, in atomicals_transaction
    return await self.session_mgr.get_transaction_detail(txid)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/session.py", line 1058, in get_transaction_detail
    blueprint_builder = AtomicalsTransferBlueprintBuilder(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: AtomicalsTransferBlueprintBuilder.__init__() missing 1 required positional argument: 'is_custom_coloring_activated'
```


```
WARNING:SessionManager:Traceback (most recent call last):
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_middleware.py", line 61, in middleware_handler
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_middleware.py", line 115, in middleware_handler
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/http_session.py", line 1792, in atomicals_transaction
    return await self.session_mgr.get_transaction_detail(txid)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/skywalker/atomicals-electrumx/electrumx/server/session.py", line 1174, in get_transaction_detail
    "value": output_ft.satvalue
             ^^^^^^^^^^^^^^^^^^
AttributeError: 'AtomicalColoredOutputFt' object has no attribute 'satvalue'
```