### PR TITLE
Fix z op payload

### DIFF
--- a/electrumx/lib/atomicals_blueprint_builder.py
+++ b/electrumx/lib/atomicals_blueprint_builder.py
@@ -480,15 +480,18 @@ class AtomicalsTransferBlueprintBuilder:
             remaining_value = atomical_info.atomical_value
             for out_idx, txout in enumerate(tx.outputs):
                 compact_atomical_id = location_id_bytes_to_compact(atomical_id)
-                compact_atomical_id_data = operations_found_at_inputs["payload"].get(compact_atomical_id, {})
-                expected_value = compact_atomical_id_data.get(str(out_idx), 0)
+                compact_atomical_id_data = {
+                    int(k): v
+                    for k, v in operations_found_at_inputs.get("payload", {}).get(compact_atomical_id, {}).items()
+                }
+                expected_value = compact_atomical_id_data.get(out_idx, 0)
                 if expected_value <= 0 or remaining_value <= 0:
                     continue
                 # if payload try to color two or more outputs, it will try to color output 0.
                 if len(compact_atomical_id_data.keys()) > 1:
                     expected_output_index = 0
                 else:
-                    if str(out_idx) not in compact_atomical_id_data.keys():  # if out_idx not in payload keys, skip
+                    if out_idx not in compact_atomical_id_data.keys():  # if out_idx not in payload keys, skip
                         continue
                     expected_output_index = out_idx
                 if not output_colored_map.get(expected_output_index):
@@ -573,11 +576,11 @@ class AtomicalsTransferBlueprintBuilder:
             for out_idx, txout in enumerate(tx.outputs):
                 expected_output_index = out_idx
                 compact_atomical_id = location_id_bytes_to_compact(atomical_id)
-                expected_value = (
-                    operations_found_at_inputs["payload"]
-                    .get(compact_atomical_id, {})
-                    .get(str(expected_output_index), 0)
-                )
+                compact_atomical_id_data = {
+                    int(k): v
+                    for k, v in operations_found_at_inputs.get("payload", {}).get(compact_atomical_id, {}).items()
+                }
+                expected_value = compact_atomical_id_data.get(expected_output_index, 0)
                 # if expected_value <= 0, ft will burn
                 if expected_value <= 0 or remaining_value <= 0:
                     continue

--- a/tests/lib/test_atomicals_blueprint_builder.py
+++ b/tests/lib/test_atomicals_blueprint_builder.py
@@ -1654,3 +1654,42 @@ def test_custom_colored_nft_normal():
     assert len(ft_output_blueprint.outputs) == 0
     assert ft_output_blueprint.fts_burned == {}
     assert blueprint_builder.get_are_fts_burned() == False
+
+    operation_found_at_inputs["payload"]["6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0"] = {
+        "1": 546
+    }
+    atomicals_spent_at_inputs = {
+        0: [
+            {
+                "atomical_id": subject_atomical_id,
+                "location_id": b"not_used",
+                "data": b"not_used",
+                "data_value": {"sat_value": 546, "atomical_value": 546},
+            }
+        ]
+    }
+
+    def mock_mint_fetcher(self, atomical_id):
+        return {
+            "atomical_id": atomical_id,
+            # set for nft
+            "type": "NFT",
+        }
+
+    blueprint_builder = AtomicalsTransferBlueprintBuilder(
+        MockLogger(),
+        atomicals_spent_at_inputs,
+        operation_found_at_inputs,
+        tx_hash,
+        tx,
+        mock_mint_fetcher,
+        True,
+        True,
+    )
+    nft_output_blueprint = blueprint_builder.get_nft_output_blueprint()
+    assert len(nft_output_blueprint.outputs) == 1
+    ft_output_blueprint = blueprint_builder.get_ft_output_blueprint()
+    assert ft_output_blueprint.cleanly_assigned == True
+    assert len(ft_output_blueprint.outputs) == 0
+    assert ft_output_blueprint.fts_burned == {}
+    assert blueprint_builder.get_are_fts_burned() == False

--- a/tests/lib/test_atomicals_blueprint_builder.py
+++ b/tests/lib/test_atomicals_blueprint_builder.py
@@ -1617,7 +1617,7 @@ def test_custom_colored_nft_normal():
     operation_found_at_inputs = parse_protocols_operations_from_witness_array(tx, tx_hash, True)
     # try to custom nft to output 1
     operation_found_at_inputs["payload"]["6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0"] = {
-        "1": 546
+        1: 546
     }
     atomicals_spent_at_inputs = {
         0: [


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


Set z payload index from str to int. both all can pass and custom color. int will better.
```
payload = {
"6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0": {
    1: 546
  }
}
```

```
payload = {
"6787f39b5d2fc020eb0f8e68cd925f297065c5c82c86d175cce1a9beaa411239i0": {
    "1": 546
  }
}
```

Both payloads are compatible with custom colored operations.