### PR TITLE
Fix transaction inputs outputs calculation error.

### DIFF
--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2214,7 +2214,6 @@ class BlockProcessor:
 
         # Log that there were tokens burned due to not being cleanly assigned
         if blueprint_builder.get_are_fts_burned():
-            self.put_op_data(tx_num, tx_hash, "burn")
             self.logger.debug(
                 f"color_atomicals_outputs:are_fts_burned=True tx_hash={tx_hash} ft_output_blueprint={ft_output_blueprint}"
             )

--- a/electrumx/server/session/session_manager.py
+++ b/electrumx/server/session/session_manager.py
@@ -1095,8 +1095,8 @@ class SessionManager:
                         result[_i.txin_index].append(_data)
             return result
 
-        async def make_transfer_outputs(result, output: Dict) -> Dict[int, List[Dict]]:
-            for k, v in blueprint_builder.ft_output_blueprint.outputs.items():
+        async def make_transfer_outputs(result, outputs: Dict) -> Dict[int, List[Dict]]:
+            for k, v in outputs:
                 for _atomical_id, _output in v["atomicals"].items():
                     _compact_atomical_id = location_id_bytes_to_compact(_atomical_id)
                     _data = {

--- a/electrumx/server/session/session_manager.py
+++ b/electrumx/server/session/session_manager.py
@@ -1096,7 +1096,7 @@ class SessionManager:
             return result
 
         def make_transfer_outputs(result, outputs: Dict) -> Dict[int, List[Dict]]:
-            for k, v in outputs:
+            for k, v in outputs.items():
                 for _atomical_id, _output in v["atomicals"].items():
                     _compact_atomical_id = location_id_bytes_to_compact(_atomical_id)
                     _data = {

--- a/electrumx/server/session/session_manager.py
+++ b/electrumx/server/session/session_manager.py
@@ -1095,7 +1095,7 @@ class SessionManager:
                         result[_i.txin_index].append(_data)
             return result
 
-        async def make_transfer_outputs(result, outputs: Dict) -> Dict[int, List[Dict]]:
+        def make_transfer_outputs(result, outputs: Dict) -> Dict[int, List[Dict]]:
             for k, v in outputs:
                 for _atomical_id, _output in v["atomicals"].items():
                     _compact_atomical_id = location_id_bytes_to_compact(_atomical_id)
@@ -1117,12 +1117,12 @@ class SessionManager:
             if not operation_type and not op_raw:
                 op_raw = "transfer"
             await make_transfer_inputs(res["transfers"]["inputs"], blueprint_builder.ft_atomicals, tx.inputs, "FT")
-            await make_transfer_outputs(res["transfers"]["outputs"], blueprint_builder.ft_output_blueprint.outputs)
+            make_transfer_outputs(res["transfers"]["outputs"], blueprint_builder.ft_output_blueprint.outputs)
         if blueprint_builder.nft_atomicals and atomicals_spent_at_inputs:
             if not operation_type and not op_raw:
                 op_raw = "transfer"
             await make_transfer_inputs(res["transfers"]["inputs"], blueprint_builder.nft_atomicals, tx.inputs, "NFT")
-            await make_transfer_outputs(res["transfers"]["outputs"], blueprint_builder.nft_output_blueprint.outputs)
+            make_transfer_outputs(res["transfers"]["outputs"], blueprint_builder.nft_output_blueprint.outputs)
 
         (
             payment_id,


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

Refactor `make_transfer_inputs` and `make_transfer_outputs` function.

```
if blueprint_builder.ft_atomicals and atomicals_spent_at_inputs:
            if not operation_type and not op_raw:
                op_raw = "transfer"
            for atomical_id, input_ft in blueprint_builder.ft_atomicals.items():
                compact_atomical_id = location_id_bytes_to_compact(atomical_id)
                res["transfers"]["inputs"] = await make_transfer_inputs(tx.inputs, compact_atomical_id, input_ft, "FT")
            for k, v in blueprint_builder.ft_output_blueprint.outputs.items():
                res["transfers"]["outputs"] = make_transfer_outputs(k, v)
        if blueprint_builder.nft_atomicals and atomicals_spent_at_inputs:
            if not operation_type and not op_raw:
                op_raw = "transfer"
            for atomical_id, input_nft in blueprint_builder.nft_atomicals.items():
                compact_atomical_id = location_id_bytes_to_compact(atomical_id)
                res["transfers"]["inputs"] = await make_transfer_inputs(
                    tx.inputs, compact_atomical_id, input_nft, "NFT"
                )
            for k, v in blueprint_builder.nft_output_blueprint.outputs.items():
                res["transfers"]["outputs"] = make_transfer_outputs(k, v)
```

res["transfers"]["outputs"] need append, Direct assignment is not possible as it will cause overwriting. If the output contains both FT and NFT, the result will be overwritten, leading to errors.
