### PR TITLE
Fix Atomicals undo entry length

### DIFF
--- a/electrumx/lib/atomicals_blueprint_builder.py
+++ b/electrumx/lib/atomicals_blueprint_builder.py
@@ -793,7 +793,7 @@ class AtomicalsTransferBlueprintBuilder:
             #     atomicals_entry['data'][HASHX_LEN + SCRIPTHASH_LEN : HASHX_LEN + SCRIPTHASH_LEN + 8]
             # )
             # exponent, = unpack_le_uint16_from(
-            #     atomicals_entry['data'][HASHX_LEN + SCRIPTHASH_LEN + 8: HASHX_LEN + SCRIPTHASH_LEN + 8 + 2]
+            #     atomicals_entry['data'][HASHX_LEN + SCRIPTHASH_LEN + 8: HASHX_LEN + SCRIPTHASH_LEN + 8 + 8]
             # )
             sat_value = atomicals_entry["data_value"]["sat_value"]
             atomical_value = atomicals_entry["data_value"]["atomical_value"]

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -4150,7 +4150,7 @@ class BlockProcessor:
         if atomicals_undo_info is None:
             raise ChainError(f"no atomicals undo information found for height " f"{self.height:,d}")
         m = len(atomicals_undo_info)
-        atomicals_undo_entry_len = ATOMICAL_ID_LEN + ATOMICAL_ID_LEN + HASHX_LEN + SCRIPTHASH_LEN + 8 + 2 + TXNUM_LEN
+        atomicals_undo_entry_len = ATOMICAL_ID_LEN + ATOMICAL_ID_LEN + HASHX_LEN + SCRIPTHASH_LEN + 8 + 8 + TXNUM_LEN
         atomicals_count = m / atomicals_undo_entry_len
         # has_undo_info_for_atomicals = False
         # if m > 0:


### PR DESCRIPTION
This applies the missing corresponding change to https://github.com/atomicals/atomicals-electrumx/pull/161/files#diff-95341b67a92c9dfb8874065355fc5f7f5d616eab77ff0079cbd9846b886b56b7R625 which fixes the reorg undo entries.

```console
2024-06-14 04:28:01,531ERROR:electrumx:ElectrumX server terminated abnormally:
Traceback (most recent call last):
  File "/data/atomicals-electrumx/electrumx_server", line 50, in main
    asyncio.run(controller.run())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/data/atomicals-electrumx/electrumx/lib/server_base.py", line 132, in run
    await server_task
  File "/data/atomicals-electrumx/electrumx/lib/server_base.py", line 106, in serve
    await self.serve(shutdown_event)
  File "/data/atomicals-electrumx/electrumx/server/controller.py", line 134, in serve
    async with OldTaskGroup() as group:
  File "/usr/local/lib/python3.10/dist-packages/aiorpcx/curio.py", line 304, in aexit
    await self.join()
  File "/data/atomicals-electrumx/electrumx/lib/util.py", line 384, in join
    task.result()
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 4487, in fetch_and_process_blocks
    async with OldTaskGroup() as group:
  File "/usr/local/lib/python3.10/dist-packages/aiorpcx/curio.py", line 304, in aexit
    await self.join()
  File "/data/atomicals-electrumx/electrumx/lib/util.py", line 384, in join
    task.result()
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 4450, in _process_prefetched_blocks
    await self.check_and_advance_blocks(blocks)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 313, in check_and_advance_blocks
    await self.reorg_chain()
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 356, in reorg_chain
    await self.run_in_thread_with_lock(self.backup_blocks, raw_blocks)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 283, in run_in_thread_with_lock
    return await asyncio.shield(run_in_thread_locked())
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 281, in run_in_thread_locked
    return await run_in_thread(func, *args)
  File "/usr/local/lib/python3.10/dist-packages/aiorpcx/curio.py", line 57, in run_in_thread
    return await get_event_loop().run_in_executor(None, func, *args)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 3950, in backup_blocks
    self.backup_txs(block.transactions, is_unspendable)
  File "/data/atomicals-electrumx/electrumx/server/block_processor.py", line 4168, in backup_txs
    assert c >= 0
AssertionError
```