### PR TITLE
fix `/proxy` and `/proxy/health` response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build
 .mypy_cache/
 .idea/
 .env
+.venv

--- a/electrumx/server/session/http_session.py
+++ b/electrumx/server/session/http_session.py
@@ -212,7 +212,7 @@ class HttpSession(object):
 
         return result
 
-    async def proxy(self):
+    async def proxy(self, request):
         result = {
             "success": True,
             "info": {

--- a/electrumx/server/session/http_session.py
+++ b/electrumx/server/session/http_session.py
@@ -144,16 +144,19 @@ class HttpSession(object):
             "blockchain.atomicals.transaction_by_scripthash": self.ss.transaction_by_scripthash,
             "blockchain.atomicals.transaction_global": self.session_mgr.transaction_global,
         }
+
         if protocols >= (1, 4, 2):
             handlers["blockchain.scripthash.unsubscribe"] = self.ss.scripthash_unsubscribe
+
+        router.add_get("/proxy", self.proxy)
+        router.add_post("/proxy", self.proxy)
+
         for m, h in handlers.items():
             method = f"/proxy/{m}"
             router.add_get(method, lambda r, handler=h: self.formatted_request(r, handler))
             router.add_post(method, lambda r, handler=h: self.formatted_request(r, handler))
 
         # Fallback proxy recognition
-        router.add_get("/proxy", self.proxy)
-        router.add_post("/proxy", self.proxy)
         router.add_get("/proxy/{method}", self.handle_get_method)
         router.add_post("/proxy/{method}", self.handle_post_method)
 
@@ -227,11 +230,11 @@ class HttpSession(object):
                 "license": "MIT",
             },
         }
-        return web.json_response(data=result)
+        return result
 
     async def health(self):
         result = {"success": True, "health": True}
-        return web.json_response(data=result)
+        return result
 
     async def donation_address(self):
         """Return the donation address as a string, empty if there is none."""


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->
Electrumx Version: 1.5.0.1

After synced with current height:
1. `/prxoy` throw `HttpSession.proxy() takes 1 positional argument but 2 were given`
2. `/proxy/health` throw `Object of type Response is not JSON serializable`