### PR TITLE
Fix `atomicals_get_by_container_item_validation` when the container is not sealed

### DIFF
--- a/electrumx/server/session/shared_session.py
+++ b/electrumx/server/session/shared_session.py
@@ -666,7 +666,8 @@ class SharedSession(object):
             errors = container_dmint_status.get("errors")
             if check_without_sealed and errors and len(errors) == 1 and errors[0] == "container not sealed":
                 pass
-            raise RPCError(BAD_REQUEST, f"Container dmint status is invalid: {errors}")
+            else:
+                raise RPCError(BAD_REQUEST, f"Container dmint status is invalid: {errors}")
 
         dmint = container_dmint_status.get("dmint")
         status, candidate_atomical_id, all_entries = self.bp.get_effective_dmitem(found_parent, item_name, height)


### PR DESCRIPTION
The `else` condition must be missing during the refactor.

The implementation in v1.4.2:
https://github.com/atomicals/atomicals-electrumx/blob/b75f5fe940c169688a21c8e1a78909b26824a638/electrumx/server/session.py#L2053-L2056