### PR TITLE
Fix `circulating_supply` ValueError, and fix custom color payload

### DIFF
--- a/electrumx/lib/atomicals_blueprint_builder.py
+++ b/electrumx/lib/atomicals_blueprint_builder.py
@@ -15,6 +15,7 @@ from electrumx.lib.util_atomicals import (
     is_splat_operation,
     is_split_operation,
     location_id_bytes_to_compact,
+    safe_int_conversion,
 )
 
 
@@ -491,7 +492,7 @@ class AtomicalsTransferBlueprintBuilder:
             for out_idx, _txout in enumerate(tx.outputs):
                 compact_atomical_id = location_id_bytes_to_compact(atomical_id)
                 compact_atomical_id_data = {
-                    int(k): v
+                    safe_int_conversion(k, -1): safe_int_conversion(v, 0)
                     for k, v in operations_found_at_inputs.get("payload", {}).get(compact_atomical_id, {}).items()
                 }
                 expected_value = compact_atomical_id_data.get(out_idx, 0)
@@ -588,7 +589,7 @@ class AtomicalsTransferBlueprintBuilder:
                 expected_output_index = out_idx
                 compact_atomical_id = location_id_bytes_to_compact(atomical_id)
                 compact_atomical_id_data = {
-                    int(k): v
+                    safe_int_conversion(k, -1): safe_int_conversion(v, 0)
                     for k, v in operations_found_at_inputs.get("payload", {}).get(compact_atomical_id, {}).items()
                 }
                 expected_value = compact_atomical_id_data.get(expected_output_index, 0)

--- a/electrumx/lib/util_atomicals.py
+++ b/electrumx/lib/util_atomicals.py
@@ -2134,3 +2134,10 @@ def validate_merkle_proof_dmint(
             return True, concat_str4, target_hash
 
     return False, None, None
+
+
+def safe_int_conversion(x, default=0):
+    try:
+        return int(x)
+    except (ValueError, TypeError):
+        return default

--- a/electrumx/server/block_processor.py
+++ b/electrumx/server/block_processor.py
@@ -2720,13 +2720,12 @@ class BlockProcessor:
         active_supply = 0
         atomical_active_location_key_prefix = b"a" + atomical_id
         for (
-            _atomical_active_location_key,
+            atomical_active_location_key,
             atomical_active_location_value,
         ) in self.db.utxo_db.iterator(prefix=atomical_active_location_key_prefix):
-            (location_value,) = unpack_le_uint64(
-                atomical_active_location_value[HASHX_LEN + SCRIPTHASH_LEN : HASHX_LEN + SCRIPTHASH_LEN + 8]
-            )
-            active_supply += location_value
+            location = atomical_active_location_key[1 + ATOMICAL_ID_LEN : 1 + ATOMICAL_ID_LEN + ATOMICAL_ID_LEN]
+            atomical_value = self.db.get_uxto_atomicals_value(location, atomical_id)
+            active_supply += atomical_value
             scripthash = atomical_active_location_value[HASHX_LEN : HASHX_LEN + SCRIPTHASH_LEN]
             unique_holders[scripthash] = True
         atomical_result["unique_holders"] = len(unique_holders)


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->


1. `circulating_supply` must use atomcal-value, not utxo value,
2. fix custom color payload: payload must be safely convert to int, it can't be float. *If it cannot be correctly converted to an integer, it will be assigned a value of 0.*