### PR TITLE
fix: wrong build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools", "setuptools-scm]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "atomicals-electrumx"
@@ -25,7 +25,7 @@ authors = [
 ]
 description = "Atomicals ElectrumX Server"
 readme = "README.rst"
-license = "MIT Licence"
+license = {text = "MIT Licence"}
 keywords = ["atomicals", "ElectrumX"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
<!-- Note: Our primary focus is supporting Bitcoin, and contributions in that regard are appreciated the most!
Due to historical reasons, ElectrumX also has support for many altcoins. These will be kept as long as
maintenance burden can be kept *at a minimum*. When adding a new altcoin, (1) add a unit test (see tests/blocks),
and (2) make sure the CI tests pass. -->

Revert build-system to `setuptools`, otherwise we can't use `setup.py` to include extra packages.