### PR TITLE
Remove verbose option from `get_realm_info`

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -464,7 +464,7 @@ class NameMixin:
         data_placeholders = 0
 
         for opcode in opcodes:
-            if type(opcode) == tuple:
+            if isinstance(opcode, tuple):
                 data_placeholders += 1
             else:
                 break

--- a/electrumx/server/session/shared_session.py
+++ b/electrumx/server/session/shared_session.py
@@ -351,7 +351,7 @@ class SharedSession(object):
         return {"global": await self._get_summary_info(), "result": entries}
 
     # Get a summary view of a realm and if it's allowing mints and what parts already existed of a subrealm
-    async def atomicals_get_realm_info(self, full_name, verbose=False):
+    async def atomicals_get_realm_info(self, full_name):
         if not full_name or not isinstance(full_name, str):
             raise RPCError(BAD_REQUEST, f"invalid input full_name: {full_name}")
         full_name = full_name.lower()
@@ -504,11 +504,10 @@ class SharedSession(object):
                 candidates, self.bp.build_atomical_id_to_candidate_map(candidates)
             ),
         }
-        if verbose:
-            populate_rules_response_struct(
-                compact_to_location_id_bytes(nearest_parent_realm_atomical_id),
-                return_struct,
-            )
+        populate_rules_response_struct(
+            compact_to_location_id_bytes(nearest_parent_realm_atomical_id),
+            return_struct,
+        )
         return {"result": return_struct}
 
     async def atomicals_get_by_realm(self, name):


### PR DESCRIPTION
The difference in verbosed outputs are little so it can be safely removed. The remain `verbose`s are for transactions queries.