### PR TITLE
Fix RPC endpoint calls

### DIFF
--- a/electrumx/server/session/rpc_session.py
+++ b/electrumx/server/session/rpc_session.py
@@ -1,0 +1,29 @@
+from electrumx.server.session.session_base import SessionBase
+
+
+class LocalRPC(SessionBase):
+    """A local TCP RPC server session."""
+
+    processing_timeout = 10**9  # disable timeouts
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client = "RPC"
+        self.connection.max_response_size = 0
+        self.request_handlers = {
+            "getinfo": self.session_mgr.rpc_getinfo,
+            "groups": self.session_mgr.rpc_groups,
+            "peers": self.session_mgr.rpc_peers,
+            "sessions": self.session_mgr.rpc_sessions,
+            "stop": self.session_mgr.rpc_stop,
+            "disconnect": self.session_mgr.rpc_disconnect,
+            "add_peer": self.session_mgr.rpc_add_peer,
+            "daemon_url": self.session_mgr.rpc_daemon_url,
+            "query": self.session_mgr.rpc_query,
+            "reorg": self.session_mgr.rpc_reorg,
+            "debug_memusage_list_all_objects": self.session_mgr.rpc_debug_memusage_list_all_objects,
+            "debug_memusage_get_random_backref_chain": self.session_mgr.rpc_debug_memusage_get_random_backref_chain,
+        }
+
+    def protocol_version_string(self):
+        return "RPC"

--- a/electrumx/server/session/session_base.py
+++ b/electrumx/server/session/session_base.py
@@ -141,17 +141,3 @@ class SessionBase(RPCSession):
             return await coro
         else:
             return coro
-
-
-class LocalRPC(SessionBase):
-    """A local TCP RPC server session."""
-
-    processing_timeout = 10**9  # disable timeouts
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.client = "RPC"
-        self.connection.max_response_size = 0
-
-    def protocol_version_string(self):
-        return "RPC"

--- a/electrumx/server/session/session_base.py
+++ b/electrumx/server/session/session_base.py
@@ -73,6 +73,9 @@ class SessionBase(RPCSession):
             maybe_bump_cost=self.bump_cost,
         )
 
+    def protocol_version_string(self):
+        raise NotImplementedError
+
     async def notify(self, touched, height_changed):
         pass
 

--- a/electrumx/server/session/session_manager.py
+++ b/electrumx/server/session/session_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import math
 import os
 import ssl
@@ -8,7 +7,7 @@ from asyncio import Event, sleep
 from collections import defaultdict
 from functools import partial
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import attr
 import pylru
@@ -174,7 +173,7 @@ class SessionManager:
                 else:
                     sslc = None
                 if service.protocol == "rpc":
-                    session_class = Type["LocalRPC"]
+                    session_class = LocalRPC
                 else:
                     session_class = self.env.coin.SESSIONCLS
                 if service.protocol in ("ws", "wss"):

--- a/electrumx/server/session/session_manager.py
+++ b/electrumx/server/session/session_manager.py
@@ -45,7 +45,7 @@ from electrumx.server.mempool import MemPool
 from electrumx.server.peers import PeerManager
 from electrumx.server.session import BAD_REQUEST, DAEMON_ERROR
 from electrumx.server.session.http_session import HttpSession
-from electrumx.server.session.session_base import LocalRPC
+from electrumx.server.session.rpc_session import LocalRPC
 from electrumx.server.session.util import SESSION_PROTOCOL_MAX, non_negative_integer
 from electrumx.version import electrumx_version
 

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -132,6 +132,8 @@ def main():
     if port is None:
         port = int(environ.get("RPC_PORT", 8000))
     method = args.pop("command")
+    if not method:
+        raise Exception("Must specify a method")
     timeout = args.pop("timeout")
 
     # aiorpcX makes this so easy...

--- a/electrumx_rpc
+++ b/electrumx_rpc
@@ -34,7 +34,6 @@ simple_commands = {
 
 session_commands = {
     "disconnect": "Disconnect sessions",
-    "log": "Control logging of sessions",
 }
 
 other_commands = {


### PR DESCRIPTION
RPC handlers were accidentally dropped during the session refactoring. Fixes #223